### PR TITLE
Add version support to retrieval

### DIFF
--- a/packages/api/secrets/models.go
+++ b/packages/api/secrets/models.go
@@ -31,6 +31,7 @@ type RetrieveSecretV3RawRequest struct {
 	SecretPath     string `json:"secretPath,omitempty"`
 	Type           string `json:"type,omitempty"`
 	IncludeImports bool   `json:"include_imports"`
+	Version        int    `json:"version"`
 }
 
 type RetrieveSecretV3RawResponse struct {

--- a/packages/api/secrets/retrieve_secret.go
+++ b/packages/api/secrets/retrieve_secret.go
@@ -21,6 +21,11 @@ func CallRetrieveSecretV3(httpClient *resty.Client, request RetrieveSecretV3RawR
 		request.SecretPath = "/"
 	}
 
+	var version string
+	if request.Version > 0 {
+		version = fmt.Sprintf("%d", request.Version)
+	}
+
 	req := httpClient.R().
 		SetResult(&retrieveResponse).
 		SetQueryParams(map[string]string{
@@ -29,6 +34,7 @@ func CallRetrieveSecretV3(httpClient *resty.Client, request RetrieveSecretV3RawR
 			"secretPath":      request.SecretPath,
 			"include_imports": fmt.Sprintf("%t", request.IncludeImports),
 			"type":            request.Type,
+			"version":         version,
 		})
 
 	res, err := req.Get(fmt.Sprintf("/v3/secrets/raw/%s", request.SecretKey))


### PR DESCRIPTION
When retrieving a secret, one might want to get a specific version. While the API supports it, the go SDK does not allow specifying a version.

This PR allows specifying the version with the `RetrieveSecretV3RawRequest`. The version will only be added to the actual request if it is non-zero.