### PR TITLE
feat: automatic token refreshing

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -27,7 +27,7 @@ type KubernetesAuthLoginOptions struct {
 // func epochTime() time.Time { return time.Unix(0, 0) }
 
 type AuthInterface interface {
-	SetAccessToken(accessToken string) (credential MachineIdentityCredential, err error)
+	SetAccessToken(accessToken string)
 	UniversalAuthLogin(clientID string, clientSecret string) (credential MachineIdentityCredential, err error)
 	KubernetesAuthLogin(identityID string, serviceAccountTokenPath string) (credential MachineIdentityCredential, err error)
 	KubernetesRawServiceAccountTokenLogin(identityID string, serviceAccountToken string) (credential MachineIdentityCredential, err error)
@@ -42,20 +42,8 @@ type Auth struct {
 	client *InfisicalClient
 }
 
-func (a *Auth) SetAccessToken(accessToken string) (credential MachineIdentityCredential, err error) {
-
-	renewedToken, err := api.CallRenewAccessToken(a.client.httpClient, api.RenewAccessTokenRequest{
-		AccessToken: accessToken,
-	})
-
-	if err != nil {
-		return MachineIdentityCredential{}, err
-	}
-
-	a.client.setAccessToken(renewedToken, models.AccessTokenCredential{AccessToken: accessToken}, util.ACCESS_TOKEN)
-
-	return renewedToken, nil
-
+func (a *Auth) SetAccessToken(accessToken string) {
+	a.client.setPlainAccessToken(accessToken)
 }
 
 func (a *Auth) UniversalAuthLogin(clientID string, clientSecret string) (credential MachineIdentityCredential, err error) {

--- a/client.go
+++ b/client.go
@@ -1,12 +1,25 @@
 package infisical
 
 import (
+	"fmt"
+	"sync"
+	"time"
+
 	"github.com/go-resty/resty/v2"
+	api "github.com/infisical/go-sdk/packages/api/auth"
+	"github.com/infisical/go-sdk/packages/models"
 	"github.com/infisical/go-sdk/packages/util"
 )
 
 type InfisicalClient struct {
-	authMethod util.AuthMethod
+	authMethod       util.AuthMethod
+	credential       interface{}
+	tokenDetails     MachineIdentityCredential
+	lastFetchedTime  time.Time
+	firstFetchedTime time.Time
+
+	mu sync.RWMutex
+
 	httpClient *resty.Client
 	config     Config
 
@@ -16,31 +29,80 @@ type InfisicalClient struct {
 }
 
 type InfisicalClientInterface interface {
-	UpdateConfiguration(config Config)
+	UpdateConfiguration(config *Config)
 	Secrets() SecretsInterface
 	Folders() FoldersInterface
 	Auth() AuthInterface
 }
 
 type Config struct {
-	SiteUrl   string
-	UserAgent string // optional, we set this when instantiating the client in the k8s operator / cli.
+	SiteUrl          string
+	UserAgent        string // optional, we set this when instantiating the client in the k8s operator / cli.
+	AutoTokenRefresh bool   // defaults to trues
+	SilentMode       bool   // defaults to false
 }
 
-func (c *InfisicalClient) setAccessToken(accessToken string, authMethod util.AuthMethod) {
-	// We check if the accessToken starts with "Bearer ", and if it does, we remove it from the accessToken
-	const bearerPrefix = "Bearer "
-	if len(accessToken) >= len(bearerPrefix) && accessToken[:len(bearerPrefix)] == bearerPrefix {
-		accessToken = accessToken[len(bearerPrefix):]
+func NewInfisicalClientConfig(options ...func(*Config)) *Config {
+	cfg := &Config{
+		SiteUrl:          util.DEFAULT_INFISICAL_API_URL,
+		UserAgent:        "infisical-go-sdk",
+		AutoTokenRefresh: true,
+		SilentMode:       false,
 	}
 
-	c.authMethod = authMethod
-	c.httpClient.SetAuthScheme("Bearer")
-	c.httpClient.SetAuthToken(accessToken)
+	for _, opt := range options {
+		opt(cfg)
+	}
+	return cfg
 }
 
-func NewInfisicalClient(config Config) InfisicalClientInterface {
+func WithSiteUrl(siteUrl string) func(*Config) {
+	return func(s *Config) {
+		s.SiteUrl = siteUrl
+	}
+}
+
+func WithUserAgent(userAgent string) func(*Config) {
+	return func(s *Config) {
+		s.UserAgent = userAgent
+	}
+}
+
+func WithAutoTokenRefresh(autoTokenRefresh bool) func(*Config) {
+	return func(s *Config) {
+		s.AutoTokenRefresh = autoTokenRefresh
+	}
+}
+
+func WithSilentMode(silentMode bool) func(*Config) {
+	return func(s *Config) {
+		s.SilentMode = silentMode
+	}
+}
+
+func (c *InfisicalClient) setAccessToken(tokenDetails MachineIdentityCredential, credential interface{}, authMethod util.AuthMethod) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.tokenDetails = tokenDetails
+	c.lastFetchedTime = time.Now()
+
+	if c.authMethod != authMethod || c.firstFetchedTime.IsZero() {
+		c.firstFetchedTime = time.Now()
+		c.authMethod = authMethod
+	}
+
+	c.credential = credential
+	c.httpClient.SetAuthScheme("Bearer")
+	c.httpClient.SetAuthToken(c.tokenDetails.AccessToken)
+}
+
+func NewInfisicalClient(config *Config) InfisicalClientInterface {
 	client := &InfisicalClient{}
+
+	if config == nil {
+		config = NewInfisicalClientConfig()
+	}
 
 	client.UpdateConfiguration(config) // set httpClient and config
 
@@ -49,26 +111,28 @@ func NewInfisicalClient(config Config) InfisicalClientInterface {
 	client.folders = &Folders{client: client}
 	client.auth = &Auth{client: client}
 
-	return client
+	if config.AutoTokenRefresh {
+		go client.handleTokenLifeCycle()
+	}
 
+	return client
 }
 
-func (c *InfisicalClient) UpdateConfiguration(config Config) {
+func (c *InfisicalClient) UpdateConfiguration(config *Config) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	if config.UserAgent == "" {
-		config.UserAgent = "infisical-go-sdk"
-	}
-	if config.SiteUrl == "" {
-		config.SiteUrl = util.DEFAULT_INFISICAL_API_URL
-	}
 	config.SiteUrl = util.AppendAPIEndpoint(config.SiteUrl)
-
-	c.config = config
+	c.config = *config
 
 	if c.httpClient == nil {
-		c.httpClient = resty.New().SetHeader("User-Agent", config.UserAgent).SetBaseURL(config.SiteUrl)
+		c.httpClient = resty.New().
+			SetHeader("User-Agent", config.UserAgent).
+			SetBaseURL(config.SiteUrl)
 	} else {
-		c.httpClient.SetHeader("User-Agent", config.UserAgent).SetBaseURL(config.SiteUrl)
+		c.httpClient.
+			SetHeader("User-Agent", config.UserAgent).
+			SetBaseURL(config.SiteUrl)
 	}
 }
 
@@ -82,4 +146,118 @@ func (c *InfisicalClient) Folders() FoldersInterface {
 
 func (c *InfisicalClient) Auth() AuthInterface {
 	return c.auth
+}
+
+func (c *InfisicalClient) handleTokenLifeCycle() {
+	var warningPrinted = false
+	authStrategies := map[util.AuthMethod]func(cred interface{}) (credential MachineIdentityCredential, err error){
+		util.UNIVERSAL_AUTH: func(cred interface{}) (credential MachineIdentityCredential, err error) {
+			if parsedCreds, ok := cred.(models.UniversalAuthCredential); ok {
+				return c.auth.UniversalAuthLogin(parsedCreds.ClientID, parsedCreds.ClientSecret)
+			}
+			return MachineIdentityCredential{}, fmt.Errorf("failed to parse UniversalAuthCredential")
+		},
+		util.KUBERNETES: func(cred interface{}) (credential MachineIdentityCredential, err error) {
+			if parsedCreds, ok := cred.(models.KubernetesCredential); ok {
+				return c.auth.KubernetesRawServiceAccountTokenLogin(parsedCreds.IdentityID, parsedCreds.ServiceAccountToken)
+			}
+			return MachineIdentityCredential{}, fmt.Errorf("failed to parse KubernetesAuthCredential")
+		},
+		util.AZURE: func(cred interface{}) (credential MachineIdentityCredential, err error) {
+			if parsedCreds, ok := cred.(models.AzureCredential); ok {
+				return c.auth.AzureAuthLogin(parsedCreds.IdentityID, parsedCreds.Resource)
+			}
+			return MachineIdentityCredential{}, fmt.Errorf("failed to parse AzureAuthCredential")
+		},
+		util.GCP_ID_TOKEN: func(cred interface{}) (credential MachineIdentityCredential, err error) {
+			if parsedCreds, ok := cred.(models.GCPIDTokenCredential); ok {
+				return c.auth.GcpIdTokenAuthLogin(parsedCreds.IdentityID)
+			}
+
+			return MachineIdentityCredential{}, fmt.Errorf("failed to parse GCPIDTokenCredential")
+		},
+		util.GCP_IAM: func(cred interface{}) (credential MachineIdentityCredential, err error) {
+			if parsedCreds, ok := cred.(models.GCPIAMCredential); ok {
+				return c.auth.GcpIamAuthLogin(parsedCreds.IdentityID, parsedCreds.ServiceAccountKeyFilePath)
+			}
+			return MachineIdentityCredential{}, fmt.Errorf("failed to parse GCPIAMCredential")
+		},
+		util.AWS_IAM: func(cred interface{}) (credential MachineIdentityCredential, err error) {
+			if parsedCreds, ok := cred.(models.AWSIAMCredential); ok {
+				return c.auth.AwsIamAuthLogin(parsedCreds.IdentityID)
+			}
+
+			return MachineIdentityCredential{}, fmt.Errorf("failed to parse AWSIAMCredential")
+		},
+	}
+
+	for {
+
+		c.mu.RLock()
+		config := c.config
+		authMethod := c.authMethod
+		tokenDetails := c.tokenDetails
+		clientCredential := c.credential
+		c.mu.RUnlock()
+
+		if config.AutoTokenRefresh && authMethod != "" {
+
+			if !config.SilentMode && !warningPrinted && tokenDetails.AccessTokenMaxTTL != 0 && tokenDetails.ExpiresIn != 0 {
+				if tokenDetails.AccessTokenMaxTTL < 60 || tokenDetails.ExpiresIn < 60 {
+					util.PrintWarning("Machine Identity access token TTL or max TTL is less than 60 seconds. This may cause excessive API calls, and you may be subject to rate-limits.")
+				}
+				warningPrinted = true
+			}
+
+			c.mu.RLock()
+
+			timeNow := time.Now()
+			timeSinceLastFetchSeconds := timeNow.Sub(c.lastFetchedTime).Seconds()
+			timeSinceFirstFetchSeconds := timeNow.Sub(c.firstFetchedTime).Seconds()
+			c.mu.RUnlock()
+
+			if timeSinceFirstFetchSeconds >= float64(tokenDetails.AccessTokenMaxTTL-10) {
+				newToken, err := authStrategies[c.authMethod](clientCredential)
+
+				if err != nil && !config.SilentMode {
+					util.PrintWarning(fmt.Sprintf("Failed to re-authenticate: %s\n", err.Error()))
+				} else {
+					c.setAccessToken(newToken, c.credential, c.authMethod)
+					// fmt.Println("Access token successfully re-authenticated\n")
+					c.mu.Lock()
+					c.firstFetchedTime = time.Now()
+					c.mu.Unlock()
+				}
+
+			} else if timeSinceLastFetchSeconds >= float64(tokenDetails.ExpiresIn-5) {
+				// fmt.Printf("Access token expired, renewing...\n")
+
+				renewedCredential, err := api.CallRenewAccessToken(c.httpClient, api.RenewAccessTokenRequest{AccessToken: tokenDetails.AccessToken})
+
+				if err != nil {
+					if !config.SilentMode {
+						util.PrintWarning(fmt.Sprintf("Failed to renew access token: %s", err.Error()))
+					}
+				} else {
+					// fmt.Println("Access token successfully renewed\n")
+					c.setAccessToken(renewedCredential, clientCredential, authMethod)
+				}
+			}
+
+			c.mu.RLock()
+			nextAccessTokenExpiresInTime := c.lastFetchedTime.Add(time.Duration(tokenDetails.ExpiresIn*int64(time.Second)) - (5 * time.Second))
+			accessTokenMaxTTLExpiresInTime := c.firstFetchedTime.Add(time.Duration(tokenDetails.AccessTokenMaxTTL*int64(time.Second)) - (5 * time.Second))
+			expiresIn := time.Duration(c.tokenDetails.ExpiresIn * int64(time.Second))
+			c.mu.RUnlock()
+
+			if nextAccessTokenExpiresInTime.After(accessTokenMaxTTLExpiresInTime) {
+				time.Sleep(expiresIn - nextAccessTokenExpiresInTime.Sub(accessTokenMaxTTLExpiresInTime))
+			} else {
+				time.Sleep(expiresIn - (5 * time.Second))
+			}
+		} else {
+			time.Sleep(5 * time.Second)
+		}
+
+	}
 }

--- a/client.go
+++ b/client.go
@@ -101,6 +101,15 @@ func (c *InfisicalClient) setAccessToken(tokenDetails MachineIdentityCredential,
 	c.httpClient.SetAuthToken(c.tokenDetails.AccessToken)
 }
 
+func (c *InfisicalClient) setPlainAccessToken(accessToken string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.authMethod = util.ACCESS_TOKEN
+	c.httpClient.SetAuthScheme("Bearer")
+	c.httpClient.SetAuthToken(accessToken)
+}
+
 func NewInfisicalClient(config *Config) InfisicalClientInterface {
 	client := &InfisicalClient{}
 
@@ -204,7 +213,7 @@ func (c *InfisicalClient) handleTokenLifeCycle() {
 		clientCredential := c.credential
 		c.mu.RUnlock()
 
-		if config.AutoTokenRefresh && authMethod != "" {
+		if config.AutoTokenRefresh && authMethod != "" && authMethod != util.ACCESS_TOKEN {
 
 			if !config.SilentMode && !warningPrinted && tokenDetails.AccessTokenMaxTTL != 0 && tokenDetails.ExpiresIn != 0 {
 				if tokenDetails.AccessTokenMaxTTL < 60 || tokenDetails.ExpiresIn < 60 {

--- a/client.go
+++ b/client.go
@@ -56,24 +56,28 @@ func NewInfisicalClientConfig(options ...func(*Config)) *Config {
 	return cfg
 }
 
+// The site URL of the Infisical instance. The default value is `https://app.infisical.com`.
 func WithSiteUrl(siteUrl string) func(*Config) {
 	return func(s *Config) {
 		s.SiteUrl = siteUrl
 	}
 }
 
+// The user agent to be used in the HTTP requests. If not set, it will default to `infisical-go-sdk`, and this is not recommended to be changed unless necessary.
 func WithUserAgent(userAgent string) func(*Config) {
 	return func(s *Config) {
 		s.UserAgent = userAgent
 	}
 }
 
+// If set to true, the client will automatically refresh the access token when it is about to expire. If set to false, the client will not refresh the access token automatically. The default value is `true`.
 func WithAutoTokenRefresh(autoTokenRefresh bool) func(*Config) {
 	return func(s *Config) {
 		s.AutoTokenRefresh = autoTokenRefresh
 	}
 }
 
+// If set to true, the client will not print any warning messages. If set to false, the client will print warning messages when necessary. The default value is `false`.
 func WithSilentMode(silentMode bool) func(*Config) {
 	return func(s *Config) {
 		s.SilentMode = silentMode

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.24.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/fatih/color v1.17.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -33,6 +34,8 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.5 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/iam v1.1.11
 	github.com/aws/aws-sdk-go-v2 v1.27.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.18
+	github.com/fatih/color v1.17.0
 	github.com/go-resty/resty/v2 v2.13.1
 	google.golang.org/api v0.188.0
 )
@@ -25,7 +26,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.24.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
-	github.com/fatih/color v1.17.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
+github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -84,6 +86,11 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.5 h1:8gw9KZK8TiVKB6q3zHY3SBzLnrGp6HQjyfYBYGmXdxA=
 github.com/googleapis/gax-go/v2 v2.12.5/go.mod h1:BUDKcWo+RaKq5SC9vVYL0wLADa3VcfswbOMMRmB9H3E=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -154,7 +161,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/packages/api/auth/aws_iam_auth_login.go
+++ b/packages/api/auth/aws_iam_auth_login.go
@@ -10,7 +10,11 @@ const callAWSIamAuthLoginOperation = "CallAWSIamAuthLogin"
 func CallAWSIamAuthLogin(httpClient *resty.Client, request AwsIamAuthLoginRequest) (credential MachineIdentityAuthLoginResponse, e error) {
 	var responseData MachineIdentityAuthLoginResponse
 
-	response, err := httpClient.R().
+	clonedClient := httpClient.Clone()
+	clonedClient.SetAuthToken("")
+	clonedClient.SetAuthScheme("")
+
+	response, err := clonedClient.R().
 		SetResult(&responseData).
 		SetBody(request).
 		Post("/v1/auth/aws-auth/login")

--- a/packages/api/auth/azure_auth_login.go
+++ b/packages/api/auth/azure_auth_login.go
@@ -10,7 +10,11 @@ const azureAuthLoginOperation = "CallAzureAuthLogin"
 func CallAzureAuthLogin(httpClient *resty.Client, request AzureAuthLoginRequest) (credential MachineIdentityAuthLoginResponse, e error) {
 	var responseData MachineIdentityAuthLoginResponse
 
-	response, err := httpClient.R().
+	clonedClient := httpClient.Clone()
+	clonedClient.SetAuthToken("")
+	clonedClient.SetAuthScheme("")
+
+	response, err := clonedClient.R().
 		SetResult(&responseData).
 		SetBody(request).
 		Post("/v1/auth/azure-auth/login")

--- a/packages/api/auth/gcp_id_token_auth_login.go
+++ b/packages/api/auth/gcp_id_token_auth_login.go
@@ -10,7 +10,11 @@ const callGCPAuthLoginOperation = "CallGCPAuthLogin"
 func CallGCPAuthLogin(httpClient *resty.Client, request GCPAuthLoginRequest) (credential MachineIdentityAuthLoginResponse, e error) {
 	var responseData MachineIdentityAuthLoginResponse
 
-	response, err := httpClient.R().
+	clonedClient := httpClient.Clone()
+	clonedClient.SetAuthToken("")
+	clonedClient.SetAuthScheme("")
+
+	response, err := clonedClient.R().
 		SetResult(&responseData).
 		SetBody(request).
 		Post("/v1/auth/gcp-auth/login")

--- a/packages/api/auth/kubernetes_auth_login.go
+++ b/packages/api/auth/kubernetes_auth_login.go
@@ -10,7 +10,11 @@ const callKubernetesAuthLoginOperation = "CallKubernetesAuthLogin"
 func CallKubernetesAuthLogin(httpClient *resty.Client, request KubernetesAuthLoginRequest) (credential MachineIdentityAuthLoginResponse, e error) {
 	var responseData MachineIdentityAuthLoginResponse
 
-	response, err := httpClient.R().
+	clonedClient := httpClient.Clone()
+	clonedClient.SetAuthToken("")
+	clonedClient.SetAuthScheme("")
+
+	response, err := clonedClient.R().
 		SetResult(&responseData).
 		SetBody(request).
 		Post("/v1/auth/kubernetes-auth/login")

--- a/packages/api/auth/models.go
+++ b/packages/api/auth/models.go
@@ -40,3 +40,7 @@ type MachineIdentityAuthLoginResponse struct {
 	AccessTokenMaxTTL int64  `json:"accessTokenMaxTTL"`
 	TokenType         string `json:"tokenType"`
 }
+
+type RenewAccessTokenRequest struct {
+	AccessToken string `json:"accessToken"`
+}

--- a/packages/api/auth/oidc_auth_login.go
+++ b/packages/api/auth/oidc_auth_login.go
@@ -10,7 +10,11 @@ const callOidcAuthLoginOperation = "CallOidcAuthLogin"
 func CallOidcAuthLogin(httpClient *resty.Client, request OidcAuthLoginRequest) (credential MachineIdentityAuthLoginResponse, e error) {
 	var responseData MachineIdentityAuthLoginResponse
 
-	response, err := httpClient.R().
+	clonedClient := httpClient.Clone()
+	clonedClient.SetAuthToken("")
+	clonedClient.SetAuthScheme("")
+
+	response, err := clonedClient.R().
 		SetResult(&responseData).
 		SetBody(request).
 		Post("/v1/auth/oidc-auth/login")

--- a/packages/api/auth/renew_access_token.go
+++ b/packages/api/auth/renew_access_token.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callRenewAccessToken = "CallRenewAccessToken"
+
+func CallRenewAccessToken(httpClient *resty.Client, request RenewAccessTokenRequest) (credential MachineIdentityAuthLoginResponse, e error) {
+	var responseData MachineIdentityAuthLoginResponse
+
+	clonedClient := httpClient.Clone()
+	clonedClient.SetAuthToken("")
+	clonedClient.SetAuthScheme("")
+
+	response, err := clonedClient.R().
+		SetResult(&responseData).
+		SetBody(request).
+		Post("/v1/auth/token/renew")
+
+	if err != nil {
+		return responseData, errors.NewRequestError(callRenewAccessToken, err)
+	}
+
+	if response.IsError() {
+		return responseData, errors.NewAPIError(callRenewAccessToken, response)
+	}
+
+	return responseData, nil
+}

--- a/packages/api/auth/universal_auth_login.go
+++ b/packages/api/auth/universal_auth_login.go
@@ -10,7 +10,11 @@ const callUniversalAuthLoginOperation = "CallUniversalAuthLogin"
 func CallUniversalAuthLogin(httpClient *resty.Client, request UniversalAuthLoginRequest) (credential MachineIdentityAuthLoginResponse, e error) {
 	var responseData MachineIdentityAuthLoginResponse
 
-	response, err := httpClient.R().
+	clonedClient := httpClient.Clone()
+	clonedClient.SetAuthToken("")
+	clonedClient.SetAuthScheme("")
+
+	response, err := clonedClient.R().
 		SetResult(&responseData).
 		SetBody(request).
 		Post("/v1/auth/universal-auth/login")

--- a/packages/models/auth.go
+++ b/packages/models/auth.go
@@ -5,3 +5,40 @@ type TokenType string
 const (
 	BEARER_TOKEN_TYPE TokenType = "Bearer"
 )
+
+type UniversalAuthCredential struct {
+	ClientID     string
+	ClientSecret string
+}
+
+type AccessTokenCredential struct {
+	AccessToken string
+}
+
+type GCPIDTokenCredential struct {
+	IdentityID string
+}
+
+type GCPIAMCredential struct {
+	IdentityID                string
+	ServiceAccountKeyFilePath string
+}
+
+type AWSIAMCredential struct {
+	IdentityID string
+}
+
+type KubernetesCredential struct {
+	IdentityID          string
+	ServiceAccountToken string
+}
+
+type AzureCredential struct {
+	IdentityID string
+	Resource   string
+}
+
+type OIDCCredential struct {
+	IdentityID string
+	JWT        string
+}

--- a/packages/util/helper.go
+++ b/packages/util/helper.go
@@ -2,9 +2,11 @@ package util
 
 import (
 	"encoding/json"
+	"os"
 	"sort"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/go-resty/resty/v2"
 	"github.com/infisical/go-sdk/packages/models"
 )
@@ -20,6 +22,10 @@ func AppendAPIEndpoint(siteUrl string) string {
 		return siteUrl + "api"
 	}
 	return siteUrl + "/api"
+}
+
+func PrintWarning(message string) {
+	color.New(color.FgYellow).Fprintf(os.Stderr, "[Infisical] Warning: %v \n", message)
 }
 
 func EnsureUniqueSecretsByKey(secrets *[]models.Secret) {


### PR DESCRIPTION
This PR introduces automatic token refreshing. Additionally, I've also modified the way that the Infisical SDK is created. Previously we were using a Config struct, but this not ideal if you want to have default values that are opposite of the Go Lang default value _(example: a boolean will always default to false, so if the user doesn't specify anything, we have no way of knowing if they are specifying false, or nothing. And in this case, we want nothing to equal true. Another approach to this would be to use pointer values, but that in itself will degrade user experience)_. The new SDK client options are built as functional options.

Example of functional options:
```go
client := infisical.NewInfisicalClient(infisical.NewInfisicalClientConfig(
   // infisical.WithAutoTokenRefresh(false), // If not specifically set to false, it will default to true!
   infisical.WithSiteUrl("https://app.infisical.com/api"),
))
```