### PR TITLE
fix: added context support

### DIFF
--- a/packages/util/auth.go
+++ b/packages/util/auth.go
@@ -119,7 +119,6 @@ func GetAwsEC2IdentityDocumentRegion(timeout int) (string, error) {
 	var identityDocument AwsIdentityDocument
 	err = json.Unmarshal(res.Body(), &identityDocument)
 	if err != nil {
-		fmt.Printf("JSON unmarshal error: %v\n", err)
 		return "", err
 	}
 

--- a/packages/util/constants.go
+++ b/packages/util/constants.go
@@ -1,5 +1,10 @@
 package util
 
+import (
+	"context"
+	"errors"
+)
+
 // Auth related:
 const (
 
@@ -54,3 +59,6 @@ const (
 	DEFAULT_INFISICAL_API_URL                     = "https://app.infisical.com/api"
 	DEFAULT_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
+
+var ErrContextCanceled = errors.New("context canceled")
+var ErrContextDeadlineExceeded error = context.DeadlineExceeded

--- a/packages/util/helper.go
+++ b/packages/util/helper.go
@@ -1,10 +1,12 @@
 package util
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/go-resty/resty/v2"
@@ -91,5 +93,13 @@ func TryParseErrorBody(res *resty.Response) string {
 	}
 
 	return errorResponse.Message
+}
 
+func SleepWithContext(ctx context.Context, duration time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(duration):
+		return nil
+	}
 }


### PR DESCRIPTION
There is currently a bug in the PR which leads to the goroutine for authentication not to be cleaned up properly. This is resolved by adding a context parameter to the SDK client, which will then clean up the gorotuine once it detects that the context has been cancelled.