### PR TITLE
fix: re-authenticate when token cannot be renewed

### DIFF
--- a/packages/util/helper.go
+++ b/packages/util/helper.go
@@ -3,12 +3,12 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/go-resty/resty/v2"
 	"github.com/infisical/go-sdk/packages/models"
 )
@@ -27,7 +27,7 @@ func AppendAPIEndpoint(siteUrl string) string {
 }
 
 func PrintWarning(message string) {
-	color.New(color.FgYellow).Fprintf(os.Stderr, "[Infisical] Warning: %v \n", message)
+	fmt.Fprintf(os.Stderr, "[Infisical] Warning: %v \n", message)
 }
 
 func EnsureUniqueSecretsByKey(secrets *[]models.Secret) {


### PR DESCRIPTION
This PR fixes a bug in the token lifecycle handler. The handler will now attempt to re-authenticate if we know the token's TTL will be longer than the tokens max TTL. Additionally I've also removed the yellow logging from the PrintWarning function. 