### PR TITLE
Dynamic secret support

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,9 +111,9 @@ func NewInfisicalClient(context context.Context, config Config) InfisicalClientI
 	client.UpdateConfiguration(config) // set httpClient and config
 
 	// add interfaces here
-	client.secrets = &Secrets{client: client}
-	client.folders = &Folders{client: client}
-	client.auth = &Auth{client: client}
+	client.secrets = NewSecrets(client)
+	client.folders = NewFolders(client)
+	client.auth = NewAuth(client)
 	client.dynamicSecrets = NewDynamicSecrets(client)
 
 	if config.AutoTokenRefresh {

--- a/client.go
+++ b/client.go
@@ -27,9 +27,10 @@ type InfisicalClient struct {
 	httpClient *resty.Client
 	config     Config
 
-	secrets SecretsInterface
-	folders FoldersInterface
-	auth    AuthInterface
+	secrets        SecretsInterface
+	folders        FoldersInterface
+	auth           AuthInterface
+	dynamicSecrets DynamicSecretsInterface
 }
 
 type InfisicalClientInterface interface {
@@ -37,6 +38,7 @@ type InfisicalClientInterface interface {
 	Secrets() SecretsInterface
 	Folders() FoldersInterface
 	Auth() AuthInterface
+	DynamicSecrets() DynamicSecretsInterface
 }
 
 type Config struct {
@@ -112,6 +114,7 @@ func NewInfisicalClient(context context.Context, config Config) InfisicalClientI
 	client.secrets = &Secrets{client: client}
 	client.folders = &Folders{client: client}
 	client.auth = &Auth{client: client}
+	client.dynamicSecrets = NewDynamicSecrets(client)
 
 	if config.AutoTokenRefresh {
 		go client.handleTokenLifeCycle(context)
@@ -149,6 +152,10 @@ func (c *InfisicalClient) Folders() FoldersInterface {
 
 func (c *InfisicalClient) Auth() AuthInterface {
 	return c.auth
+}
+
+func (c *InfisicalClient) DynamicSecrets() DynamicSecretsInterface {
+	return c.dynamicSecrets
 }
 
 func (c *InfisicalClient) handleTokenLifeCycle(context context.Context) {

--- a/dynamic_secrets.go
+++ b/dynamic_secrets.go
@@ -1,0 +1,102 @@
+package infisical
+
+import (
+	api "github.com/infisical/go-sdk/packages/api/dynamic_secrets"
+	"github.com/infisical/go-sdk/packages/models"
+)
+
+type ListDynamicSecretLeasesOptions = api.ListDynamicSecretLeaseV1Request
+type CreateDynamicSecretLeaseOptions = api.CreateDynamicSecretLeaseV1Request
+type DeleteDynamicSecretLeaseOptions = api.DeleteDynamicSecretLeaseV1Request
+type GetDynamicSecretLeaseByIdOptions = api.GetDynamicSecretLeaseByIdV1Request
+type RenewDynamicSecretLeaseOptions = api.RenewDynamicSecretLeaseV1Request
+type ListDynamicSecretsRootCredentialsOptions = api.ListDynamicSecretsV1Request
+type GetDynamicSecretRootCredentialByNameOptions = api.GetDynamicSecretByNameV1Request
+
+type DynamicSecretsInterface interface {
+	ListRootCredentials(options ListDynamicSecretsRootCredentialsOptions) ([]models.DynamicSecret, error)
+	GetRootCredentialByName(options GetDynamicSecretRootCredentialByNameOptions) (models.DynamicSecret, error)
+	ListLeases(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error)
+	CreateLease(options CreateDynamicSecretLeaseOptions) (map[string]any, models.DynamicSecret, models.DynamicSecretLease, error)
+	GetLeaseById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error)
+	DeleteLeaseById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
+	RenewLeaseById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
+}
+
+type DynamicSecrets struct {
+	client *InfisicalClient
+}
+
+func (f *DynamicSecrets) ListRootCredentials(options ListDynamicSecretsRootCredentialsOptions) ([]models.DynamicSecret, error) {
+	res, err := api.CallListDynamicSecretsV1(f.client.httpClient, options)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.DynamicSecrets, nil
+}
+
+func (f *DynamicSecrets) GetRootCredentialByName(options GetDynamicSecretRootCredentialByNameOptions) (models.DynamicSecret, error) {
+	res, err := api.CallGetDynamicSecretByNameV1(f.client.httpClient, options)
+
+	if err != nil {
+		return models.DynamicSecret{}, err
+	}
+
+	return res.DynamicSecret, nil
+}
+
+func (f *DynamicSecrets) ListLeases(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error) {
+	res, err := api.CallListDynamicSecretLeaseV1(f.client.httpClient, options)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Leases, nil
+}
+
+func (f *DynamicSecrets) CreateLease(options CreateDynamicSecretLeaseOptions) (map[string]any, models.DynamicSecret, models.DynamicSecretLease, error) {
+	res, err := api.CallCreateDynamicSecretLeaseV1(f.client.httpClient, options)
+
+	if err != nil {
+		return nil, models.DynamicSecret{}, models.DynamicSecretLease{}, err
+	}
+
+	return res.Data, res.DynamicSecret, res.Lease, nil
+}
+
+func (f *DynamicSecrets) GetLeaseById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error) {
+	res, err := api.CallGetByDynamicSecretByIdLeaseV1(f.client.httpClient, options)
+
+	if err != nil {
+		return models.DynamicSecretLeaseWithDynamicSecret{}, err
+	}
+
+	return res.Lease, nil
+}
+
+func (f *DynamicSecrets) DeleteLeaseById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
+	res, err := api.CallDeleteDynamicSecretLeaseV1(f.client.httpClient, options)
+
+	if err != nil {
+		return models.DynamicSecretLease{}, err
+	}
+
+	return res.Lease, nil
+}
+
+func (f *DynamicSecrets) RenewLeaseById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
+	res, err := api.CallRenewDynamicSecretLeaseV1(f.client.httpClient, options)
+
+	if err != nil {
+		return models.DynamicSecretLease{}, err
+	}
+
+	return res.Lease, nil
+}
+
+func NewDynamicSecrets(client *InfisicalClient) DynamicSecretsInterface {
+	return &DynamicSecrets{client: client}
+}

--- a/dynamic_secrets.go
+++ b/dynamic_secrets.go
@@ -19,16 +19,12 @@ type DynamicSecretsInterface interface {
 	Leases() DynamicSecretLeaseInterface
 }
 
-type DynamicSecretLeases struct {
-	client *InfisicalClient
-}
-
 type DynamicSecretLeaseInterface interface {
 	List(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error)
 	Create(options CreateDynamicSecretLeaseOptions) (map[string]any, models.DynamicSecret, models.DynamicSecretLease, error)
-	Retrieve(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error)
-	Delete(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
-	Renew(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
+	GetById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error)
+	DeleteById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
+	RenewById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
 }
 
 type DynamicSecrets struct {
@@ -60,6 +56,10 @@ func (f *DynamicSecrets) Leases() DynamicSecretLeaseInterface {
 	return f.leases
 }
 
+type DynamicSecretLeases struct {
+	client *InfisicalClient
+}
+
 func (f *DynamicSecretLeases) List(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error) {
 	res, err := api.CallListDynamicSecretLeaseV1(f.client.httpClient, options)
 
@@ -80,7 +80,7 @@ func (f *DynamicSecretLeases) Create(options CreateDynamicSecretLeaseOptions) (m
 	return res.Data, res.DynamicSecret, res.Lease, nil
 }
 
-func (f *DynamicSecretLeases) Retrieve(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error) {
+func (f *DynamicSecretLeases) GetById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error) {
 	res, err := api.CallGetByDynamicSecretByIdLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -90,7 +90,7 @@ func (f *DynamicSecretLeases) Retrieve(options GetDynamicSecretLeaseByIdOptions)
 	return res.Lease, nil
 }
 
-func (f *DynamicSecretLeases) Delete(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
+func (f *DynamicSecretLeases) DeleteById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
 	res, err := api.CallDeleteDynamicSecretLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -100,7 +100,7 @@ func (f *DynamicSecretLeases) Delete(options DeleteDynamicSecretLeaseOptions) (m
 	return res.Lease, nil
 }
 
-func (f *DynamicSecretLeases) Renew(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
+func (f *DynamicSecretLeases) RenewById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
 	res, err := api.CallRenewDynamicSecretLeaseV1(f.client.httpClient, options)
 
 	if err != nil {

--- a/dynamic_secrets.go
+++ b/dynamic_secrets.go
@@ -14,20 +14,25 @@ type ListDynamicSecretsRootCredentialsOptions = api.ListDynamicSecretsV1Request
 type GetDynamicSecretRootCredentialByNameOptions = api.GetDynamicSecretByNameV1Request
 
 type DynamicSecretsInterface interface {
-	ListRootCredentials(options ListDynamicSecretsRootCredentialsOptions) ([]models.DynamicSecret, error)
-	GetRootCredentialByName(options GetDynamicSecretRootCredentialByNameOptions) (models.DynamicSecret, error)
-	ListLeases(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error)
-	CreateLease(options CreateDynamicSecretLeaseOptions) (map[string]any, models.DynamicSecret, models.DynamicSecretLease, error)
-	GetLeaseById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error)
-	DeleteLeaseById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
-	RenewLeaseById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
+	List(options ListDynamicSecretsRootCredentialsOptions) ([]models.DynamicSecret, error)
+	GetByName(options GetDynamicSecretRootCredentialByNameOptions) (models.DynamicSecret, error)
+	Leases() DynamicSecretLeaseInterface
+}
+
+type DynamicSecretLeaseInterface interface {
+	List(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error)
+	Create(options CreateDynamicSecretLeaseOptions) (map[string]any, models.DynamicSecret, models.DynamicSecretLease, error)
+	GetById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error)
+	DeleteById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
+	RenewById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
 }
 
 type DynamicSecrets struct {
 	client *InfisicalClient
+	leases DynamicSecretLeaseInterface
 }
 
-func (f *DynamicSecrets) ListRootCredentials(options ListDynamicSecretsRootCredentialsOptions) ([]models.DynamicSecret, error) {
+func (f *DynamicSecrets) List(options ListDynamicSecretsRootCredentialsOptions) ([]models.DynamicSecret, error) {
 	res, err := api.CallListDynamicSecretsV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -37,7 +42,7 @@ func (f *DynamicSecrets) ListRootCredentials(options ListDynamicSecretsRootCrede
 	return res.DynamicSecrets, nil
 }
 
-func (f *DynamicSecrets) GetRootCredentialByName(options GetDynamicSecretRootCredentialByNameOptions) (models.DynamicSecret, error) {
+func (f *DynamicSecrets) GetByName(options GetDynamicSecretRootCredentialByNameOptions) (models.DynamicSecret, error) {
 	res, err := api.CallGetDynamicSecretByNameV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -47,7 +52,15 @@ func (f *DynamicSecrets) GetRootCredentialByName(options GetDynamicSecretRootCre
 	return res.DynamicSecret, nil
 }
 
-func (f *DynamicSecrets) ListLeases(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error) {
+func (f *DynamicSecrets) Leases() DynamicSecretLeaseInterface {
+	return f.leases
+}
+
+type DynamicSecretLeases struct {
+	client *InfisicalClient
+}
+
+func (f *DynamicSecretLeases) List(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error) {
 	res, err := api.CallListDynamicSecretLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -57,7 +70,7 @@ func (f *DynamicSecrets) ListLeases(options ListDynamicSecretLeasesOptions) ([]m
 	return res.Leases, nil
 }
 
-func (f *DynamicSecrets) CreateLease(options CreateDynamicSecretLeaseOptions) (map[string]any, models.DynamicSecret, models.DynamicSecretLease, error) {
+func (f *DynamicSecretLeases) Create(options CreateDynamicSecretLeaseOptions) (map[string]any, models.DynamicSecret, models.DynamicSecretLease, error) {
 	res, err := api.CallCreateDynamicSecretLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -67,7 +80,7 @@ func (f *DynamicSecrets) CreateLease(options CreateDynamicSecretLeaseOptions) (m
 	return res.Data, res.DynamicSecret, res.Lease, nil
 }
 
-func (f *DynamicSecrets) GetLeaseById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error) {
+func (f *DynamicSecretLeases) GetById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error) {
 	res, err := api.CallGetByDynamicSecretByIdLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -77,7 +90,7 @@ func (f *DynamicSecrets) GetLeaseById(options GetDynamicSecretLeaseByIdOptions) 
 	return res.Lease, nil
 }
 
-func (f *DynamicSecrets) DeleteLeaseById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
+func (f *DynamicSecretLeases) DeleteById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
 	res, err := api.CallDeleteDynamicSecretLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -87,7 +100,7 @@ func (f *DynamicSecrets) DeleteLeaseById(options DeleteDynamicSecretLeaseOptions
 	return res.Lease, nil
 }
 
-func (f *DynamicSecrets) RenewLeaseById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
+func (f *DynamicSecretLeases) RenewById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
 	res, err := api.CallRenewDynamicSecretLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -98,5 +111,5 @@ func (f *DynamicSecrets) RenewLeaseById(options RenewDynamicSecretLeaseOptions) 
 }
 
 func NewDynamicSecrets(client *InfisicalClient) DynamicSecretsInterface {
-	return &DynamicSecrets{client: client}
+	return &DynamicSecrets{client: client, leases: &DynamicSecretLeases{client: client}}
 }

--- a/dynamic_secrets.go
+++ b/dynamic_secrets.go
@@ -19,12 +19,16 @@ type DynamicSecretsInterface interface {
 	Leases() DynamicSecretLeaseInterface
 }
 
+type DynamicSecretLeases struct {
+	client *InfisicalClient
+}
+
 type DynamicSecretLeaseInterface interface {
 	List(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error)
 	Create(options CreateDynamicSecretLeaseOptions) (map[string]any, models.DynamicSecret, models.DynamicSecretLease, error)
-	GetById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error)
-	DeleteById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
-	RenewById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
+	Retrieve(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error)
+	Delete(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
+	Renew(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error)
 }
 
 type DynamicSecrets struct {
@@ -56,10 +60,6 @@ func (f *DynamicSecrets) Leases() DynamicSecretLeaseInterface {
 	return f.leases
 }
 
-type DynamicSecretLeases struct {
-	client *InfisicalClient
-}
-
 func (f *DynamicSecretLeases) List(options ListDynamicSecretLeasesOptions) ([]models.DynamicSecretLease, error) {
 	res, err := api.CallListDynamicSecretLeaseV1(f.client.httpClient, options)
 
@@ -80,7 +80,7 @@ func (f *DynamicSecretLeases) Create(options CreateDynamicSecretLeaseOptions) (m
 	return res.Data, res.DynamicSecret, res.Lease, nil
 }
 
-func (f *DynamicSecretLeases) GetById(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error) {
+func (f *DynamicSecretLeases) Retrieve(options GetDynamicSecretLeaseByIdOptions) (models.DynamicSecretLeaseWithDynamicSecret, error) {
 	res, err := api.CallGetByDynamicSecretByIdLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -90,7 +90,7 @@ func (f *DynamicSecretLeases) GetById(options GetDynamicSecretLeaseByIdOptions) 
 	return res.Lease, nil
 }
 
-func (f *DynamicSecretLeases) DeleteById(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
+func (f *DynamicSecretLeases) Delete(options DeleteDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
 	res, err := api.CallDeleteDynamicSecretLeaseV1(f.client.httpClient, options)
 
 	if err != nil {
@@ -100,7 +100,7 @@ func (f *DynamicSecretLeases) DeleteById(options DeleteDynamicSecretLeaseOptions
 	return res.Lease, nil
 }
 
-func (f *DynamicSecretLeases) RenewById(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
+func (f *DynamicSecretLeases) Renew(options RenewDynamicSecretLeaseOptions) (models.DynamicSecretLease, error) {
 	res, err := api.CallRenewDynamicSecretLeaseV1(f.client.httpClient, options)
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go/iam v1.1.11
 	github.com/aws/aws-sdk-go-v2 v1.27.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.18
-	github.com/fatih/color v1.17.0
 	github.com/go-resty/resty/v2 v2.13.1
 	google.golang.org/api v0.188.0
 )
@@ -34,8 +33,6 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.5 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
-github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -86,11 +84,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.5 h1:8gw9KZK8TiVKB6q3zHY3SBzLnrGp6HQjyfYBYGmXdxA=
 github.com/googleapis/gax-go/v2 v2.12.5/go.mod h1:BUDKcWo+RaKq5SC9vVYL0wLADa3VcfswbOMMRmB9H3E=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -161,9 +154,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/packages/api/dynamic_secrets/create_lease.go
+++ b/packages/api/dynamic_secrets/create_lease.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callCreateDynamicSecretLeaseV1Operation = "CallCreateDynamicSecretLeaseV1"
+
+func CallCreateDynamicSecretLeaseV1(httpClient *resty.Client, request CreateDynamicSecretLeaseV1Request) (CreateDynamicSecretLeaseV1Response, error) {
+
+	createResponse := CreateDynamicSecretLeaseV1Response{}
+
+	req := httpClient.R().
+		SetResult(&createResponse).
+		SetBody(request)
+
+	res, err := req.Post("/v1/dynamic-secrets/leases")
+
+	if err != nil {
+		return CreateDynamicSecretLeaseV1Response{}, errors.NewRequestError(callCreateDynamicSecretLeaseV1Operation, err)
+	}
+
+	if res.IsError() {
+		return CreateDynamicSecretLeaseV1Response{}, errors.NewAPIErrorWithResponse(callCreateDynamicSecretLeaseV1Operation, res)
+	}
+
+	return createResponse, nil
+}

--- a/packages/api/dynamic_secrets/delete_lease.go
+++ b/packages/api/dynamic_secrets/delete_lease.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callDeleteDynamicSecretLeaseV1Operation = "CallDeleteDynamicSecretLeaseV1"
+
+func CallDeleteDynamicSecretLeaseV1(httpClient *resty.Client, request DeleteDynamicSecretLeaseV1Request) (DeleteDynamicSecretLeaseV1Response, error) {
+
+	deleteResponse := DeleteDynamicSecretLeaseV1Response{}
+
+	req := httpClient.R().
+		SetResult(&deleteResponse).
+		SetBody(request)
+
+	res, err := req.Delete("/v1/dynamic-secrets/leases/" + request.LeaseId)
+
+	if err != nil {
+		return DeleteDynamicSecretLeaseV1Response{}, errors.NewRequestError(callDeleteDynamicSecretLeaseV1Operation, err)
+	}
+
+	if res.IsError() {
+		return DeleteDynamicSecretLeaseV1Response{}, errors.NewAPIErrorWithResponse(callDeleteDynamicSecretLeaseV1Operation, res)
+	}
+
+	return deleteResponse, nil
+}

--- a/packages/api/dynamic_secrets/get_lease_by_id.go
+++ b/packages/api/dynamic_secrets/get_lease_by_id.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callGetDynamicSecretLeaseByIdV1Operation = "CallGetDynamicSecretLeaseByIdV1"
+
+func CallGetByDynamicSecretByIdLeaseV1(httpClient *resty.Client, request GetDynamicSecretLeaseByIdV1Request) (GetDynamicSecretLeaseByIdV1Response, error) {
+
+	getByIdResponse := GetDynamicSecretLeaseByIdV1Response{}
+
+	req := httpClient.R().
+		SetResult(&getByIdResponse).
+		SetQueryParams(map[string]string{
+			"projectSlug":     request.ProjectSlug,
+			"environmentSlug": request.EnvironmentSlug,
+			"path":            request.SecretPath,
+		})
+
+	res, err := req.Get("/v1/dynamic-secrets/leases/" + request.LeaseId)
+
+	if err != nil {
+		return GetDynamicSecretLeaseByIdV1Response{}, errors.NewRequestError(callGetDynamicSecretLeaseByIdV1Operation, err)
+	}
+
+	if res.IsError() {
+		return GetDynamicSecretLeaseByIdV1Response{}, errors.NewAPIErrorWithResponse(callGetDynamicSecretLeaseByIdV1Operation, res)
+	}
+
+	return getByIdResponse, nil
+}

--- a/packages/api/dynamic_secrets/get_secret_by_name.go
+++ b/packages/api/dynamic_secrets/get_secret_by_name.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callGetDynamicSecretByNameV1Operation = "CallGetDynamicSecretSecretByNameV1"
+
+func CallGetDynamicSecretByNameV1(httpClient *resty.Client, request GetDynamicSecretByNameV1Request) (GetDynamicSecretByNameV1Response, error) {
+
+	getByNameResponse := GetDynamicSecretByNameV1Response{}
+
+	req := httpClient.R().
+		SetResult(&getByNameResponse).SetQueryParams(map[string]string{
+		"projectSlug":     request.ProjectSlug,
+		"environmentSlug": request.EnvironmentSlug,
+		"path":            request.SecretPath,
+	})
+
+	res, err := req.Get("/v1/dynamic-secrets/" + request.SecretName)
+
+	if err != nil {
+		return GetDynamicSecretByNameV1Response{}, errors.NewRequestError(callGetDynamicSecretByNameV1Operation, err)
+	}
+
+	if res.IsError() {
+		return GetDynamicSecretByNameV1Response{}, errors.NewAPIErrorWithResponse(callGetDynamicSecretByNameV1Operation, res)
+	}
+
+	return getByNameResponse, nil
+}

--- a/packages/api/dynamic_secrets/list_lease.go
+++ b/packages/api/dynamic_secrets/list_lease.go
@@ -22,11 +22,11 @@ func CallListDynamicSecretLeaseV1(httpClient *resty.Client, request ListDynamicS
 	res, err := req.Get("/v1/dynamic-secrets/" + request.SecretName + "/leases")
 
 	if err != nil {
-		return ListDynamicSecretLeaseV1Response{}, errors.NewRequestError(callGetDynamicSecretLeaseByIdV1Operation, err)
+		return ListDynamicSecretLeaseV1Response{}, errors.NewRequestError(callListDynamicSecretLeaseV1Operation, err)
 	}
 
 	if res.IsError() {
-		return ListDynamicSecretLeaseV1Response{}, errors.NewAPIErrorWithResponse(callGetDynamicSecretLeaseByIdV1Operation, res)
+		return ListDynamicSecretLeaseV1Response{}, errors.NewAPIErrorWithResponse(callListDynamicSecretLeaseV1Operation, res)
 	}
 
 	return listResponse, nil

--- a/packages/api/dynamic_secrets/list_lease.go
+++ b/packages/api/dynamic_secrets/list_lease.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callListDynamicSecretLeaseV1Operation = "CallListDynamicSecretLeaseV1"
+
+func CallListDynamicSecretLeaseV1(httpClient *resty.Client, request ListDynamicSecretLeaseV1Request) (ListDynamicSecretLeaseV1Response, error) {
+
+	listResponse := ListDynamicSecretLeaseV1Response{}
+
+	req := httpClient.R().
+		SetResult(&listResponse).
+		SetQueryParams(map[string]string{
+			"projectSlug":     request.ProjectSlug,
+			"environmentSlug": request.EnvironmentSlug,
+			"path":            request.SecretPath,
+		})
+
+	res, err := req.Get("/v1/dynamic-secrets/" + request.SecretName + "/leases")
+
+	if err != nil {
+		return ListDynamicSecretLeaseV1Response{}, errors.NewRequestError(callGetDynamicSecretLeaseByIdV1Operation, err)
+	}
+
+	if res.IsError() {
+		return ListDynamicSecretLeaseV1Response{}, errors.NewAPIErrorWithResponse(callGetDynamicSecretLeaseByIdV1Operation, res)
+	}
+
+	return listResponse, nil
+}

--- a/packages/api/dynamic_secrets/list_secrets.go
+++ b/packages/api/dynamic_secrets/list_secrets.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callListDynamicSecretsV1Operation = "CallListDynamicSecretSecretsV1"
+
+func CallListDynamicSecretsV1(httpClient *resty.Client, request ListDynamicSecretsV1Request) (ListDynamicSecretsV1Response, error) {
+
+	listDynamicSecretResponse := ListDynamicSecretsV1Response{}
+
+	req := httpClient.R().
+		SetResult(&listDynamicSecretResponse).
+		SetQueryParams(map[string]string{
+			"projectSlug":     request.ProjectSlug,
+			"environmentSlug": request.EnvironmentSlug,
+			"path":            request.SecretPath,
+		})
+
+	res, err := req.Get("/v1/dynamic-secrets")
+
+	if err != nil {
+		return ListDynamicSecretsV1Response{}, errors.NewRequestError(callGetDynamicSecretByNameV1Operation, err)
+	}
+
+	if res.IsError() {
+		return ListDynamicSecretsV1Response{}, errors.NewAPIErrorWithResponse(callGetDynamicSecretByNameV1Operation, res)
+	}
+
+	return listDynamicSecretResponse, nil
+}

--- a/packages/api/dynamic_secrets/list_secrets.go
+++ b/packages/api/dynamic_secrets/list_secrets.go
@@ -22,11 +22,11 @@ func CallListDynamicSecretsV1(httpClient *resty.Client, request ListDynamicSecre
 	res, err := req.Get("/v1/dynamic-secrets")
 
 	if err != nil {
-		return ListDynamicSecretsV1Response{}, errors.NewRequestError(callGetDynamicSecretByNameV1Operation, err)
+		return ListDynamicSecretsV1Response{}, errors.NewRequestError(callListDynamicSecretsV1Operation, err)
 	}
 
 	if res.IsError() {
-		return ListDynamicSecretsV1Response{}, errors.NewAPIErrorWithResponse(callGetDynamicSecretByNameV1Operation, res)
+		return ListDynamicSecretsV1Response{}, errors.NewAPIErrorWithResponse(callListDynamicSecretsV1Operation, res)
 	}
 
 	return listDynamicSecretResponse, nil

--- a/packages/api/dynamic_secrets/models.go
+++ b/packages/api/dynamic_secrets/models.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"github.com/infisical/go-sdk/packages/models"
+)
+
+type CreateDynamicSecretLeaseV1Request struct {
+	DynamicSecretName string `json:"dynamicSecretName"`
+	ProjectSlug       string `json:"projectSlug"`
+	TTL               string `json:"ttl"`
+	SecretPath        string `json:"path"`
+	EnvironmentSlug   string `json:"environmentSlug"`
+}
+
+type CreateDynamicSecretLeaseV1Response struct {
+	Lease         models.DynamicSecretLease `json:"lease"`
+	DynamicSecret models.DynamicSecret      `json:"dynamicSecret"`
+	Data          map[string]any            `json:"data"`
+}
+
+type DeleteDynamicSecretLeaseV1Request struct {
+	LeaseId         string `json:"leaseId"`
+	ProjectSlug     string `json:"projectSlug"`
+	SecretPath      string `json:"path"`
+	EnvironmentSlug string `json:"environmentSlug"`
+	IsForced        bool   `json:"isForced"`
+}
+
+type DeleteDynamicSecretLeaseV1Response struct {
+	Lease models.DynamicSecretLease `json:"lease"`
+}
+
+type RenewDynamicSecretLeaseV1Request struct {
+	LeaseId         string `json:"leaseId"`
+	TTL             string `json:"ttl"`
+	ProjectSlug     string `json:"projectSlug"`
+	SecretPath      string `json:"path"`
+	EnvironmentSlug string `json:"environmentSlug"`
+	IsForced        bool   `json:"isForced"`
+}
+
+type RenewDynamicSecretLeaseV1Response struct {
+	Lease models.DynamicSecretLease `json:"lease"`
+}
+
+type GetDynamicSecretLeaseByIdV1Request struct {
+	LeaseId         string `json:"leaseId"`
+	ProjectSlug     string `json:"projectSlug"`
+	SecretPath      string `json:"path"`
+	EnvironmentSlug string `json:"environmentSlug"`
+}
+
+type GetDynamicSecretLeaseByIdV1Response struct {
+	Lease models.DynamicSecretLeaseWithDynamicSecret `json:"lease"`
+}
+
+type ListDynamicSecretLeaseV1Request struct {
+	SecretName      string `json:"secretName"`
+	ProjectSlug     string `json:"projectSlug"`
+	SecretPath      string `json:"path"`
+	EnvironmentSlug string `json:"environmentSlug"`
+}
+
+type ListDynamicSecretLeaseV1Response struct {
+	Leases []models.DynamicSecretLease `json:"leases"`
+}
+
+type GetDynamicSecretByNameV1Request struct {
+	SecretName      string `json:"secretName"`
+	ProjectSlug     string `json:"projectSlug"`
+	SecretPath      string `json:"path"`
+	EnvironmentSlug string `json:"environmentSlug"`
+}
+
+type GetDynamicSecretByNameV1Response struct {
+	DynamicSecret models.DynamicSecret `json:"dynamicSecret"`
+}
+
+type ListDynamicSecretsV1Request struct {
+	ProjectSlug     string `json:"projectSlug"`
+	SecretPath      string `json:"path"`
+	EnvironmentSlug string `json:"environmentSlug"`
+}
+
+type ListDynamicSecretsV1Response struct {
+	DynamicSecrets []models.DynamicSecret `json:"dynamicSecrets"`
+}

--- a/packages/api/dynamic_secrets/models.go
+++ b/packages/api/dynamic_secrets/models.go
@@ -66,10 +66,10 @@ type ListDynamicSecretLeaseV1Response struct {
 }
 
 type GetDynamicSecretByNameV1Request struct {
-	DynamicSecretName string `json:"secretName"`
-	ProjectSlug       string `json:"projectSlug"`
-	SecretPath        string `json:"path"`
-	EnvironmentSlug   string `json:"environmentSlug"`
+	SecretName      string `json:"secretName"`
+	ProjectSlug     string `json:"projectSlug"`
+	SecretPath      string `json:"path"`
+	EnvironmentSlug string `json:"environmentSlug"`
 }
 
 type GetDynamicSecretByNameV1Response struct {

--- a/packages/api/dynamic_secrets/models.go
+++ b/packages/api/dynamic_secrets/models.go
@@ -55,10 +55,10 @@ type GetDynamicSecretLeaseByIdV1Response struct {
 }
 
 type ListDynamicSecretLeaseV1Request struct {
-	SecretName      string `json:"secretName"`
-	ProjectSlug     string `json:"projectSlug"`
-	SecretPath      string `json:"path"`
-	EnvironmentSlug string `json:"environmentSlug"`
+	DynamicSecretName string `json:"secretName"`
+	ProjectSlug       string `json:"projectSlug"`
+	SecretPath        string `json:"path"`
+	EnvironmentSlug   string `json:"environmentSlug"`
 }
 
 type ListDynamicSecretLeaseV1Response struct {
@@ -66,10 +66,10 @@ type ListDynamicSecretLeaseV1Response struct {
 }
 
 type GetDynamicSecretByNameV1Request struct {
-	SecretName      string `json:"secretName"`
-	ProjectSlug     string `json:"projectSlug"`
-	SecretPath      string `json:"path"`
-	EnvironmentSlug string `json:"environmentSlug"`
+	DynamicSecretName string `json:"secretName"`
+	ProjectSlug       string `json:"projectSlug"`
+	SecretPath        string `json:"path"`
+	EnvironmentSlug   string `json:"environmentSlug"`
 }
 
 type GetDynamicSecretByNameV1Response struct {

--- a/packages/api/dynamic_secrets/models.go
+++ b/packages/api/dynamic_secrets/models.go
@@ -66,10 +66,10 @@ type ListDynamicSecretLeaseV1Response struct {
 }
 
 type GetDynamicSecretByNameV1Request struct {
-	SecretName      string `json:"secretName"`
-	ProjectSlug     string `json:"projectSlug"`
-	SecretPath      string `json:"path"`
-	EnvironmentSlug string `json:"environmentSlug"`
+	DynamicSecretName string `json:"secretName"`
+	ProjectSlug       string `json:"projectSlug"`
+	SecretPath        string `json:"path"`
+	EnvironmentSlug   string `json:"environmentSlug"`
 }
 
 type GetDynamicSecretByNameV1Response struct {

--- a/packages/api/dynamic_secrets/renew_lease.go
+++ b/packages/api/dynamic_secrets/renew_lease.go
@@ -18,11 +18,11 @@ func CallRenewDynamicSecretLeaseV1(httpClient *resty.Client, request RenewDynami
 	res, err := req.Post("/v1/dynamic-secrets/leases/" + request.LeaseId)
 
 	if err != nil {
-		return RenewDynamicSecretLeaseV1Response{}, errors.NewRequestError(callGetDynamicSecretLeaseByIdV1Operation, err)
+		return RenewDynamicSecretLeaseV1Response{}, errors.NewRequestError(callRenewDynamicSecretLeaseV1Operation, err)
 	}
 
 	if res.IsError() {
-		return RenewDynamicSecretLeaseV1Response{}, errors.NewAPIErrorWithResponse(callGetDynamicSecretLeaseByIdV1Operation, res)
+		return RenewDynamicSecretLeaseV1Response{}, errors.NewAPIErrorWithResponse(callRenewDynamicSecretLeaseV1Operation, res)
 	}
 
 	return renewResponse, nil

--- a/packages/api/dynamic_secrets/renew_lease.go
+++ b/packages/api/dynamic_secrets/renew_lease.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callRenewDynamicSecretLeaseV1Operation = "CallRenewDynamicSecretLeaseV1"
+
+func CallRenewDynamicSecretLeaseV1(httpClient *resty.Client, request RenewDynamicSecretLeaseV1Request) (RenewDynamicSecretLeaseV1Response, error) {
+
+	renewResponse := RenewDynamicSecretLeaseV1Response{}
+
+	req := httpClient.R().
+		SetResult(&renewResponse).
+		SetBody(request)
+
+	res, err := req.Post("/v1/dynamic-secrets/leases/" + request.LeaseId)
+
+	if err != nil {
+		return RenewDynamicSecretLeaseV1Response{}, errors.NewRequestError(callGetDynamicSecretLeaseByIdV1Operation, err)
+	}
+
+	if res.IsError() {
+		return RenewDynamicSecretLeaseV1Response{}, errors.NewAPIErrorWithResponse(callGetDynamicSecretLeaseByIdV1Operation, res)
+	}
+
+	return renewResponse, nil
+}

--- a/packages/models/dynamic_secrets.go
+++ b/packages/models/dynamic_secrets.go
@@ -1,0 +1,44 @@
+package models
+
+import "time"
+
+type DynamicSecret struct {
+	Id            string    `json:"id"`
+	Name          string    `json:"name"`
+	Type          string    `json:"type"`
+	Version       int       `json:"number"`
+	DefaultTTL    string    `json:"defaultTTL"`
+	MaxTTL        string    `json:"maxTTL"`
+	FolderID      string    `json:"folderId"`
+	Status        string    `json:"status"`
+	StatusDetails string    `json:"statusDetails"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
+type DynamicSecretLease struct {
+	Id               string    `json:"id"`
+	Type             string    `json:"type"`
+	Version          int       `json:"number"`
+	ExternalEntityId string    `json:"externalEntityId"`
+	ExpireAt         time.Time `json:"expireAt"`
+	Status           string    `json:"status"`
+	DynamicSecretId  string    `json:"dynamicSecretId"`
+	StatusDetails    string    `json:"statusDetails"`
+	CreatedAt        time.Time `json:"createdAt"`
+	UpdatedAt        time.Time `json:"updatedAt"`
+}
+
+type DynamicSecretLeaseWithDynamicSecret struct {
+	Id               string        `json:"id"`
+	Type             string        `json:"type"`
+	Version          int           `json:"number"`
+	ExternalEntityId string        `json:"externalEntityId"`
+	ExpireAt         time.Time     `json:"expireAt"`
+	Status           string        `json:"status"`
+	DynamicSecretId  string        `json:"dynamicSecretId"`
+	StatusDetails    string        `json:"statusDetails"`
+	CreatedAt        time.Time     `json:"createdAt"`
+	UpdatedAt        time.Time     `json:"updatedAt"`
+	DynamicSecret    DynamicSecret `json:"dynamicSecret"`
+}

--- a/test/aws_auth_test.go
+++ b/test/aws_auth_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 
 func TestAWSAuthLogin(t *testing.T) {
 
-	client := infisical.NewInfisicalClient(infisical.Config{
+	client := infisical.NewInfisicalClient(context.Background(), infisical.Config{
 		SiteUrl: "https://c61b724baab4.ngrok.app",
 	})
 


### PR DESCRIPTION
This PR brings support to dynamic secret leasing and listing dynamic secret root credentials.  This is phase 1 to support same in CLI. 

Root credentials management is still not addded to sdk, and not planning to the CLI as well for time being. 

The plan is for now root cred management happens in UI and customers use CLI to lease and get temporary credentials.