### PR TITLE
feat: list secrets with etag support

### DIFF
--- a/packages/api/secrets/list_secrets.go
+++ b/packages/api/secrets/list_secrets.go
@@ -35,8 +35,6 @@ func CallListSecretsWithETagV3(httpClient *resty.Client, request ListSecretsV3Ra
 		}
 	}
 
-	fmt.Printf("ETAG: %s\n", request.CurrentETag)
-
 	res, err := httpClient.R().
 		SetResult(&secretsResponse).
 		SetHeader("if-none-match", request.CurrentETag).

--- a/packages/api/secrets/list_secrets.go
+++ b/packages/api/secrets/list_secrets.go
@@ -2,15 +2,71 @@ package api
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/infisical/go-sdk/packages/errors"
 )
 
 const callListSecretsV3RawOperation = "CallListSecretsV3Raw"
+const callListSecretsWithETagV3RawOperation = "CallListSecretsWithETagV3Raw"
+
+func CallListSecretsWithETagV3(httpClient *resty.Client, request ListSecretsV3RawWithETagRequest) (response ListSecretsV3RawResponse, serverETag string, isModified bool, err error) {
+
+	secretsResponse := ListSecretsV3RawResponse{}
+
+	if request.SecretPath == "" {
+		request.SecretPath = "/"
+	}
+
+	if request.CurrentETag != "" {
+
+		isWeakETag := strings.HasPrefix(request.CurrentETag, "W/")
+		if isWeakETag {
+			request.CurrentETag = strings.TrimPrefix(request.CurrentETag, "W/")
+		}
+
+		request.CurrentETag = strings.TrimPrefix(request.CurrentETag, "\"")
+		request.CurrentETag = strings.TrimSuffix(request.CurrentETag, "\"")
+		request.CurrentETag = fmt.Sprintf("\"%s\"", request.CurrentETag)
+
+		if isWeakETag {
+			request.CurrentETag = fmt.Sprintf("W/%s", request.CurrentETag)
+		}
+	}
+
+	fmt.Printf("ETAG: %s\n", request.CurrentETag)
+
+	res, err := httpClient.R().
+		SetResult(&secretsResponse).
+		SetHeader("if-none-match", request.CurrentETag).
+		SetQueryParams(map[string]string{
+			"workspaceId":            request.ProjectID,
+			"workspaceSlug":          request.ProjectSlug,
+			"environment":            request.Environment,
+			"secretPath":             request.SecretPath,
+			"expandSecretReferences": fmt.Sprintf("%t", request.ExpandSecretReferences),
+			"include_imports":        fmt.Sprintf("%t", request.IncludeImports),
+			"recursive":              fmt.Sprintf("%t", request.Recursive),
+		}).Get("/v3/secrets/raw")
+
+	if err != nil {
+		return ListSecretsV3RawResponse{}, "", false, errors.NewRequestError(callListSecretsWithETagV3RawOperation, err)
+	}
+
+	if res.IsError() {
+		return ListSecretsV3RawResponse{}, "", false, errors.NewAPIErrorWithResponse(callListSecretsWithETagV3RawOperation, res)
+	}
+
+	var modified = true
+	if res.StatusCode() == 304 || (res.Header().Get("etag") == request.CurrentETag && request.CurrentETag != "") {
+		modified = false
+	}
+
+	return secretsResponse, res.Header().Get("etag"), modified, nil
+}
 
 func CallListSecretsV3(httpClient *resty.Client, request ListSecretsV3RawRequest) (ListSecretsV3RawResponse, error) {
-
 	secretsResponse := ListSecretsV3RawResponse{}
 
 	if request.SecretPath == "" {

--- a/packages/api/secrets/models.go
+++ b/packages/api/secrets/models.go
@@ -16,6 +16,19 @@ type ListSecretsV3RawRequest struct {
 	SecretPath             string `json:"secretPath,omitempty"`
 }
 
+type ListSecretsV3RawWithETagRequest struct {
+	AttachToProcessEnv bool   `json:"-"`
+	CurrentETag        string `json:"-"`
+	// ProjectId and ProjectSlug are used to fetch secrets from the project. Only one of them is required.
+	ProjectID              string `json:"workspaceId,omitempty"`
+	ProjectSlug            string `json:"workspaceSlug,omitempty"`
+	Environment            string `json:"environment"`
+	ExpandSecretReferences bool   `json:"expandSecretReferences"`
+	IncludeImports         bool   `json:"include_imports"`
+	Recursive              bool   `json:"recursive"`
+	SecretPath             string `json:"secretPath,omitempty"`
+}
+
 type ListSecretsV3RawResponse struct {
 	Secrets []models.Secret       `json:"secrets"`
 	Imports []models.SecretImport `json:"imports"`
@@ -83,4 +96,10 @@ type DeleteSecretV3RawRequest struct {
 
 type DeleteSecretV3RawResponse struct {
 	Secret models.Secret `json:"secret"`
+}
+
+type ListSecretsWithETagResponse struct {
+	Secrets    []models.Secret
+	ETag       string
+	IsModified bool
 }

--- a/packages/models/secrets.go
+++ b/packages/models/secrets.go
@@ -12,6 +12,12 @@ type Secret struct {
 	SecretPath    string `json:"secretPath,omitempty"`
 }
 
+type ListSecretsWithETagResult struct {
+	Secrets    []Secret
+	ETag       string
+	IsModified bool
+}
+
 type SecretImport struct {
 	SecretPath  string   `json:"secretPath"`
 	Environment string   `json:"environment"`


### PR DESCRIPTION
Added ETag comparisons support to the Go SDK. This is useful for applications depending on secret updates to perform certain actions, such as our K8 operator.