### PR TITLE
feat: batch create secrets support

### DIFF
--- a/packages/api/secrets/bulk_create_secrets.go
+++ b/packages/api/secrets/bulk_create_secrets.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/infisical/go-sdk/packages/errors"
+)
+
+const callBatchCreateSecretV3RawOperation = "CallBatchCreateSecretV3Raw"
+
+func CallBatchCreateSecretV3(httpClient *resty.Client, request BatchCreateSecretsV3RawRequest) (BatchCreateSecretsV3RawResponse, error) {
+
+	createBatchResponse := BatchCreateSecretsV3RawResponse{}
+
+	req := httpClient.R().
+		SetResult(&createBatchResponse).
+		SetBody(request)
+
+	res, err := req.Post("/v3/secrets/batch/raw")
+
+	if err != nil {
+		return BatchCreateSecretsV3RawResponse{}, errors.NewRequestError(callBatchCreateSecretV3RawOperation, err)
+	}
+
+	if res.IsError() {
+		return BatchCreateSecretsV3RawResponse{}, errors.NewAPIErrorWithResponse(callBatchCreateSecretV3RawOperation, res)
+	}
+
+	for idx := range createBatchResponse.Secrets {
+
+		secretPath := request.SecretPath
+
+		if secretPath == "" {
+			secretPath = "/"
+		}
+
+		createBatchResponse.Secrets[idx].SecretPath = secretPath
+	}
+
+	return createBatchResponse, nil
+}

--- a/packages/api/secrets/models.go
+++ b/packages/api/secrets/models.go
@@ -84,3 +84,26 @@ type DeleteSecretV3RawRequest struct {
 type DeleteSecretV3RawResponse struct {
 	Secret models.Secret `json:"secret"`
 }
+
+type BatchCreateSecret struct {
+	SecretKey             string `json:"secretKey"`
+	SecretValue           string `json:"secretValue"`
+	SecretComment         string `json:"secretComment,omitempty"`
+	SkipMultiLineEncoding bool   `json:"skipMultilineEncoding,omitempty"`
+	SecretMetadata        []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"secretMetadata,omitempty"`
+	TagIDs []string `json:"tagIds,omitempty"`
+}
+
+type BatchCreateSecretsV3RawRequest struct {
+	Environment string              `json:"environment"`
+	ProjectID   string              `json:"workspaceId"`
+	SecretPath  string              `json:"secretPath,omitempty"`
+	Secrets     []BatchCreateSecret `json:"secrets"`
+}
+
+type BatchCreateSecretsV3RawResponse struct {
+	Secrets []models.Secret `json:"secrets"`
+}

--- a/packages/api/secrets/models.go
+++ b/packages/api/secrets/models.go
@@ -86,15 +86,12 @@ type DeleteSecretV3RawResponse struct {
 }
 
 type BatchCreateSecret struct {
-	SecretKey             string `json:"secretKey"`
-	SecretValue           string `json:"secretValue"`
-	SecretComment         string `json:"secretComment,omitempty"`
-	SkipMultiLineEncoding bool   `json:"skipMultilineEncoding,omitempty"`
-	SecretMetadata        []struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
-	} `json:"secretMetadata,omitempty"`
-	TagIDs []string `json:"tagIds,omitempty"`
+	SecretKey             string                  `json:"secretKey"`
+	SecretValue           string                  `json:"secretValue"`
+	SecretComment         string                  `json:"secretComment,omitempty"`
+	SkipMultiLineEncoding bool                    `json:"skipMultilineEncoding,omitempty"`
+	SecretMetadata        []models.SecretMetadata `json:"secretMetadata,omitempty"`
+	TagIDs                []string                `json:"tagIds,omitempty"`
 }
 
 type BatchCreateSecretsV3RawRequest struct {

--- a/secrets.go
+++ b/secrets.go
@@ -14,15 +14,28 @@ type UpdateSecretOptions = api.UpdateSecretV3RawRequest
 type CreateSecretOptions = api.CreateSecretV3RawRequest
 type DeleteSecretOptions = api.DeleteSecretV3RawRequest
 
+type BatchCreateSecret = api.BatchCreateSecret
+
+type BatchCreateSecretsOptions = api.BatchCreateSecretsV3RawRequest
+
+type BatchSecretsInterface interface {
+	Create(options BatchCreateSecretsOptions) ([]models.Secret, error)
+}
+
 type SecretsInterface interface {
 	List(options ListSecretsOptions) ([]models.Secret, error)
 	Retrieve(options RetrieveSecretOptions) (models.Secret, error)
 	Update(options UpdateSecretOptions) (models.Secret, error)
 	Create(options CreateSecretOptions) (models.Secret, error)
 	Delete(options DeleteSecretOptions) (models.Secret, error)
+	Batch() BatchSecretsInterface
 }
 
 type Secrets struct {
+	client *InfisicalClient
+}
+
+type BatchSecrets struct {
 	client *InfisicalClient
 }
 
@@ -102,6 +115,22 @@ func (s *Secrets) Delete(options DeleteSecretOptions) (models.Secret, error) {
 	}
 
 	return res.Secret, nil
+}
+
+// Batch operations
+
+func (bs *BatchSecrets) Create(options BatchCreateSecretsOptions) ([]models.Secret, error) {
+	res, err := api.CallBatchCreateSecretV3(bs.client.httpClient, options)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Secrets, nil
+}
+
+func (s *Secrets) Batch() BatchSecretsInterface {
+	return &BatchSecrets{client: s.client}
 }
 
 func NewSecrets(client *InfisicalClient) SecretsInterface {

--- a/secrets.go
+++ b/secrets.go
@@ -15,6 +15,7 @@ type CreateSecretOptions = api.CreateSecretV3RawRequest
 type DeleteSecretOptions = api.DeleteSecretV3RawRequest
 
 type BatchCreateSecret = api.BatchCreateSecret
+type SecretMetadata = models.SecretMetadata
 
 type BatchCreateSecretsOptions = api.BatchCreateSecretsV3RawRequest
 

--- a/test/secrets_batch_create_test.go
+++ b/test/secrets_batch_create_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	infisical "github.com/infisical/go-sdk"
+)
+
+func TestSshIssueCreds(t *testing.T) {
+	client := infisical.NewInfisicalClient(context.Background(), infisical.Config{
+		SiteUrl:          "http://localhost:8080",
+		AutoTokenRefresh: true,
+	})
+
+	client.Auth().SetAccessToken("<token>")
+
+	secs, err := client.Secrets().Batch().Create(infisical.BatchCreateSecretsOptions{
+		Environment: "dev",
+		SecretPath:  "/",
+		ProjectID:   "06c4d805-ac8a-456f-906f-1319554d15ec",
+		Secrets: []infisical.BatchCreateSecret{
+			{
+				SecretKey:   "test3",
+				SecretValue: "test1",
+			},
+			{
+				SecretKey:   "test4",
+				SecretValue: "test2",
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Failed to create secrets: %v", err)
+	}
+
+	t.Logf("Secrets: %v", secs)
+}


### PR DESCRIPTION
This PR adds support for bulk creating secrets with the Go SDK. We can further expand on the other batch methods when needed.