### PR TITLE
feat: add version param for secret retrieval

### DIFF
--- a/packages/api/secrets/models.go
+++ b/packages/api/secrets/models.go
@@ -31,6 +31,7 @@ type RetrieveSecretV3RawRequest struct {
 	SecretPath     string `json:"secretPath,omitempty"`
 	Type           string `json:"type,omitempty"`
 	IncludeImports bool   `json:"include_imports"`
+	Version        string `json:"version,omitempty"`
 }
 
 type RetrieveSecretV3RawResponse struct {

--- a/packages/api/secrets/retrieve_secret.go
+++ b/packages/api/secrets/retrieve_secret.go
@@ -47,6 +47,7 @@ func CallRetrieveSecretV3(cache *expirable.LRU[string, interface{}], httpClient 
 			"secretPath":      request.SecretPath,
 			"include_imports": fmt.Sprintf("%t", request.IncludeImports),
 			"type":            request.Type,
+			"version":         request.Version,
 		})
 
 	res, err := req.Get(fmt.Sprintf("/v3/secrets/raw/%s", request.SecretKey))


### PR DESCRIPTION
This PR adds the version parameter for secret retrieval, as described in the API docs: [Secret Retrieve](https://infisical.com/docs/api-reference/endpoints/secrets/read#parameter-environment).

Currently blocked by: [Infisical Issue #3263](https://github.com/Infisical/infisical/issues/3263).