### PR TITLE
feat: add support for fetching specific secret version

### DIFF
--- a/packages/api/secrets/models.go
+++ b/packages/api/secrets/models.go
@@ -31,6 +31,8 @@ type RetrieveSecretV3RawRequest struct {
 	SecretPath     string `json:"secretPath,omitempty"`
 	Type           string `json:"type,omitempty"`
 	IncludeImports bool   `json:"include_imports"`
+
+	Version int `json:"version,omitempty"`
 }
 
 type RetrieveSecretV3RawResponse struct {

--- a/packages/api/secrets/retrieve_secret.go
+++ b/packages/api/secrets/retrieve_secret.go
@@ -39,15 +39,21 @@ func CallRetrieveSecretV3(cache *expirable.LRU[string, interface{}], httpClient 
 		request.SecretPath = "/"
 	}
 
+	queryParams := map[string]string{
+		"workspaceId":     request.ProjectID,
+		"environment":     request.Environment,
+		"secretPath":      request.SecretPath,
+		"include_imports": fmt.Sprintf("%t", request.IncludeImports),
+		"type":            request.Type,
+	}
+
+	if request.Version != 0 {
+		queryParams["version"] = fmt.Sprintf("%d", request.Version)
+	}
+
 	req := httpClient.R().
 		SetResult(&retrieveResponse).
-		SetQueryParams(map[string]string{
-			"workspaceId":     request.ProjectID,
-			"environment":     request.Environment,
-			"secretPath":      request.SecretPath,
-			"include_imports": fmt.Sprintf("%t", request.IncludeImports),
-			"type":            request.Type,
-		})
+		SetQueryParams(queryParams)
 
 	res, err := req.Get(fmt.Sprintf("/v3/secrets/raw/%s", request.SecretKey))
 


### PR DESCRIPTION
This PR adds support for fetching a specific secret version.

Original PR [here](https://github.com/Infisical/go-sdk/pull/33).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the option to specify a version when retrieving secrets, enabling enhanced customization.
  
- **Refactor**
  - Streamlined the process for constructing query parameters, ensuring that version information is included only when relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->