### PR TITLE
feat: retry on network errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,8 +6,10 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -152,6 +154,57 @@ func (c *InfisicalClient) UpdateConfiguration(config Config) {
 		c.httpClient = resty.New().
 			SetHeader("User-Agent", config.UserAgent).
 			SetBaseURL(config.SiteUrl)
+
+		c.httpClient.SetRetryCount(3).
+			SetRetryWaitTime(1 * time.Second).
+			SetRetryMaxWaitTime(30 * time.Second).
+			SetRetryAfter(func(c *resty.Client, r *resty.Response) (time.Duration, error) {
+				attempt := r.Request.Attempt + 1
+
+				if attempt <= 0 {
+					attempt = 1
+				}
+				waitTime := math.Min(float64(c.RetryWaitTime)*math.Pow(2, float64(attempt-1)), float64(c.RetryMaxWaitTime))
+				waitDuration := time.Duration(waitTime)
+				return waitDuration, nil
+			}).
+			AddRetryCondition(func(r *resty.Response, err error) bool {
+				// don't retry if there's no error or it's a timeout
+				if err == nil || errors.Is(err, context.DeadlineExceeded) {
+					return false
+				}
+
+				errMsg := err.Error()
+
+				networkErrors := []string{
+					"connection refused",
+					"connection reset",
+					"network",
+					"connection",
+					"no such host",
+					"i/o timeout",
+					"dial tcp",
+					"broken pipe",
+					"wsaetimeout",
+					"wsaeconnreset",
+					"econnreset",
+					"econnrefused",
+					"ehostunreach",
+					"enetunreach",
+				}
+
+				isConditionMet := false
+
+				for _, netErr := range networkErrors {
+					if strings.Contains(strings.ToLower(errMsg), netErr) {
+						isConditionMet = true
+					}
+				}
+
+				fmt.Printf("isConditionMet: %v\n", isConditionMet)
+				return isConditionMet
+
+			})
 
 	} else {
 		c.httpClient.

--- a/client.go
+++ b/client.go
@@ -201,7 +201,6 @@ func (c *InfisicalClient) UpdateConfiguration(config Config) {
 					}
 				}
 
-				fmt.Printf("isConditionMet: %v\n", isConditionMet)
 				return isConditionMet
 
 			})


### PR DESCRIPTION
This PR implements automatic retries of network related errors such as ECONNRESET or host not found. It will retry 3 times, exponentially increasing the retry delay. The highest retry delay will be 8 seconds, which means the total max retry time will be 15 seconds in total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved network reliability by introducing an automatic retry mechanism that gracefully handles temporary connection issues with progressively increasing wait times before reattempting the request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->