### PR TITLE
fix: rename `IsDigest` to `IsPreDigested`

### DIFF
--- a/packages/api/kms/models.go
+++ b/packages/api/kms/models.go
@@ -22,7 +22,7 @@ type KmsSignDataV1Request struct {
 	KeyId            string
 	Data             string `json:"data"`
 	SigningAlgorithm string `json:"signingAlgorithm"`
-	IsDigest         bool   `json:"isDigest"`
+	IsPreDigested    bool   `json:"preDigested"`
 }
 
 type KmsSignDataV1Response struct {
@@ -36,7 +36,7 @@ type KmsVerifyDataV1Request struct {
 	Data             string `json:"data"` // Data must be base64 encoded
 	Signature        string `json:"signature"`
 	SigningAlgorithm string `json:"signingAlgorithm"`
-	IsDigest         bool   `json:"isDigest"`
+	IsPreDigested    bool   `json:"preDigested"`
 }
 
 type KmsVerifyDataV1Response struct {


### PR DESCRIPTION
Renames `IsDigest` field to `IsPreDigested`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated request field names in the API to use "preDigested" instead of "isDigest" for improved clarity in signing and verification operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->