### PR TITLE
Add Alias Field to SSH Add Host Method

### DIFF
--- a/packages/api/ssh/models.go
+++ b/packages/api/ssh/models.go
@@ -50,7 +50,7 @@ type SshHost struct {
 	ID            string                `json:"id"`
 	ProjectID     string                `json:"projectId"`
 	Hostname      string                `json:"hostname"`
-	Alias         string               	`json:"alias,omitempty"`
+	Alias         string                `json:"alias,omitempty"`
 	UserCertTtl   string                `json:"userCertTtl"`
 	HostCertTtl   string                `json:"hostCertTtl"`
 	UserSshCaId   string                `json:"userSshCaId"`
@@ -84,7 +84,7 @@ type IssueSshHostHostCertV1Response struct {
 type AddSshHostV1Request struct {
 	ProjectID     string                `json:"projectId"`
 	Hostname      string                `json:"hostname"`
-	Alias         string               	`json:"alias,omitempty"`
+	Alias         string                `json:"alias,omitempty"`
 	UserCertTtl   string                `json:"userCertTtl,omitempty"`
 	HostCertTtl   string                `json:"hostCertTtl,omitempty"`
 	UserSshCaId   string                `json:"userSshCaId,omitempty"`

--- a/packages/api/ssh/models.go
+++ b/packages/api/ssh/models.go
@@ -50,6 +50,7 @@ type SshHost struct {
 	ID            string                `json:"id"`
 	ProjectID     string                `json:"projectId"`
 	Hostname      string                `json:"hostname"`
+	Alias         string               	`json:"alias,omitempty"`
 	UserCertTtl   string                `json:"userCertTtl"`
 	HostCertTtl   string                `json:"hostCertTtl"`
 	UserSshCaId   string                `json:"userSshCaId"`
@@ -83,6 +84,7 @@ type IssueSshHostHostCertV1Response struct {
 type AddSshHostV1Request struct {
 	ProjectID     string                `json:"projectId"`
 	Hostname      string                `json:"hostname"`
+	Alias         string               	`json:"alias,omitempty"`
 	UserCertTtl   string                `json:"userCertTtl,omitempty"`
 	HostCertTtl   string                `json:"hostCertTtl,omitempty"`
 	UserSshCaId   string                `json:"userSshCaId,omitempty"`

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -1,4 +1,4 @@
-package test
+// package test
 
 // import (
 // 	"context"
@@ -26,6 +26,7 @@ package test
 // 	_, err = client.Ssh().AddSshHost(infisical.AddSshHostOptions{
 // 		ProjectID: "",
 // 		Hostname:  "",
+// 		Alias:     "",
 // 	})
 // 	if err != nil {
 // 		fmt.Printf("Failed to add SSH host: %v\n", err)
@@ -48,15 +49,15 @@ package test
 // 	}
 
 // 	// Test getting user CA public key for first host
-// 	userCaKey, err := client.Ssh().GetSshHostUserCaPublicKey(hosts[0].ID)
-// 	if err != nil {
-// 		t.Fatalf("Failed to get user CA public key: %v", err)
-// 	}
+// 	// userCaKey, err := client.Ssh().GetSshHostUserCaPublicKey(hosts[0].ID)
+// 	// if err != nil {
+// 	// 	t.Fatalf("Failed to get user CA public key: %v", err)
+// 	// }
 
-// 	hostCaKey, err := client.Ssh().GetSshHostHostCaPublicKey(hosts[0].ID)
-// 	if err != nil {
-// 		t.Fatalf("Failed to get host CA public key: %v", err)
-// 	}
+// 	// hostCaKey, err := client.Ssh().GetSshHostHostCaPublicKey(hosts[0].ID)
+// 	// if err != nil {
+// 	// 	t.Fatalf("Failed to get host CA public key: %v", err)
+// 	// }
 
 // 	// fmt.Printf("User CA Public Key for host %s:\n%s\n", hosts[0].Hostname, userCaKey)
 

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -1,7 +1,8 @@
-// package test
+package test
 
 // import (
 // 	"context"
+// 	"encoding/json"
 // 	"fmt"
 // 	"os"
 // 	"testing"
@@ -49,83 +50,83 @@
 // 	}
 
 // 	// Test getting user CA public key for first host
-// 	// userCaKey, err := client.Ssh().GetSshHostUserCaPublicKey(hosts[0].ID)
-// 	// if err != nil {
-// 	// 	t.Fatalf("Failed to get user CA public key: %v", err)
-// 	// }
+// 	userCaKey, err := client.Ssh().GetSshHostUserCaPublicKey(hosts[0].ID)
+// 	if err != nil {
+// 		t.Fatalf("Failed to get user CA public key: %v", err)
+// 	}
 
-// 	// hostCaKey, err := client.Ssh().GetSshHostHostCaPublicKey(hosts[0].ID)
-// 	// if err != nil {
-// 	// 	t.Fatalf("Failed to get host CA public key: %v", err)
-// 	// }
+// 	hostCaKey, err := client.Ssh().GetSshHostHostCaPublicKey(hosts[0].ID)
+// 	if err != nil {
+// 		t.Fatalf("Failed to get host CA public key: %v", err)
+// 	}
 
-// 	// fmt.Printf("User CA Public Key for host %s:\n%s\n", hosts[0].Hostname, userCaKey)
+// 	fmt.Printf("User CA Public Key for host %s:\n%s\n", hosts[0].Hostname, userCaKey)
 
-// 	// for _, host := range hosts {
-// 	// 	hostJson, err := json.MarshalIndent(host, "", "  ")
-// 	// 	if err != nil {
-// 	// 		t.Errorf("Failed to marshal host %s: %v", host.ID, err)
-// 	// 		continue
-// 	// 	}
-// 	// 	fmt.Println(string(hostJson))
-// 	// }
+// 	for _, host := range hosts {
+// 		hostJson, err := json.MarshalIndent(host, "", "  ")
+// 		if err != nil {
+// 			t.Errorf("Failed to marshal host %s: %v", host.ID, err)
+// 			continue
+// 		}
+// 		fmt.Println(string(hostJson))
+// 	}
 
-// 	// // Pick the first host
-// 	// targetHost := hosts[0]
+// 	// Pick the first host
+// 	targetHost := hosts[0]
 
-// 	// // Test issuing SSH cert for user
-// 	// creds, err := client.Ssh().IssueSshHostUserCert(targetHost.ID, infisical.IssueSshHostUserCertOptions{
-// 	// 	LoginUser: "ec2-user", // or whatever login user is appropriate
-// 	// })
-// 	// if err != nil {
-// 	// 	t.Fatalf("Failed to issue SSH credentials from host %s: %v", targetHost.ID, err)
-// 	// }
+// 	// Test issuing SSH cert for user
+// 	creds, err := client.Ssh().IssueSshHostUserCert(targetHost.ID, infisical.IssueSshHostUserCertOptions{
+// 		LoginUser: "ec2-user", // or whatever login user is appropriate
+// 	})
+// 	if err != nil {
+// 		t.Fatalf("Failed to issue SSH credentials from host %s: %v", targetHost.ID, err)
+// 	}
 
-// 	// // Display the credentials
-// 	// credsJson, err := json.MarshalIndent(creds, "", "  ")
-// 	// if err != nil {
-// 	// 	t.Fatalf("Failed to marshal issued credentials: %v", err)
-// 	// }
-// 	// fmt.Println("Issued user credentials:")
-// 	// fmt.Println(string(credsJson))
+// 	// Display the credentials
+// 	credsJson, err := json.MarshalIndent(creds, "", "  ")
+// 	if err != nil {
+// 		t.Fatalf("Failed to marshal issued credentials: %v", err)
+// 	}
+// 	fmt.Println("Issued user credentials:")
+// 	fmt.Println(string(credsJson))
 
-// 	// // Test issuing SSH cert for host
-// 	// creds2, err := client.Ssh().IssueSshHostHostCert(targetHost.ID, infisical.IssueSshHostHostCertOptions{
-// 	// 	PublicKey: "",
-// 	// })
-// 	// if err != nil {
-// 	// 	t.Fatalf("Failed to issue SSH credentials from host %s: %v", targetHost.ID, err)
-// 	// }
+// 	// Test issuing SSH cert for host
+// 	creds2, err := client.Ssh().IssueSshHostHostCert(targetHost.ID, infisical.IssueSshHostHostCertOptions{
+// 		PublicKey: "",
+// 	})
+// 	if err != nil {
+// 		t.Fatalf("Failed to issue SSH credentials from host %s: %v", targetHost.ID, err)
+// 	}
 
-// 	// // Display the credentials
-// 	// creds2Json, err := json.MarshalIndent(creds2, "", "  ")
-// 	// if err != nil {
-// 	// 	t.Fatalf("Failed to marshal issued credentials: %v", err)
-// 	// }
-// 	// fmt.Println("Issued credentials:")
-// 	// fmt.Println(string(creds2Json))
+// 	// Display the credentials
+// 	creds2Json, err := json.MarshalIndent(creds2, "", "  ")
+// 	if err != nil {
+// 		t.Fatalf("Failed to marshal issued credentials: %v", err)
+// 	}
+// 	fmt.Println("Issued credentials:")
+// 	fmt.Println(string(creds2Json))
 
-// 	// // Test issuing SSH credentials
-// 	// creds, err := client.Ssh().IssueCredentials(infisical.IssueSshCredsOptions{
-// 	// 	CertificateTemplateID: "",
-// 	// 	Principals:            []string{"ec2-user"},
-// 	// })
+// 	// Test issuing SSH credentials
+// 	creds, err := client.Ssh().IssueCredentials(infisical.IssueSshCredsOptions{
+// 		CertificateTemplateID: "",
+// 		Principals:            []string{"ec2-user"},
+// 	})
 
-// 	// if err != nil {
-// 	// 	t.Fatalf("Failed to issue SSH credentials: %v", err)
-// 	// }
+// 	if err != nil {
+// 		t.Fatalf("Failed to issue SSH credentials: %v", err)
+// 	}
 
-// 	// // Test signing SSH public key
-// 	// creds2, err := client.Ssh().SignKey(infisical.SignSshPublicKeyOptions{
-// 	// 	CertificateTemplateID: "",
-// 	// 	Principals:            []string{"ec2-user"},
-// 	// 	PublicKey:             "ssh-rsa ...",
-// 	// })
+// 	// Test signing SSH public key
+// 	creds2, err := client.Ssh().SignKey(infisical.SignSshPublicKeyOptions{
+// 		CertificateTemplateID: "",
+// 		Principals:            []string{"ec2-user"},
+// 		PublicKey:             "ssh-rsa ...",
+// 	})
 
-// 	// if err != nil {
-// 	// 	t.Fatalf("Failed to sign SSH public key: %v", err)
-// 	// }
+// 	if err != nil {
+// 		t.Fatalf("Failed to sign SSH public key: %v", err)
+// 	}
 
-// 	// fmt.Print("Newly-issued SSH credentials: ", creds)
-// 	// fmt.Print("Signed SSH credential: ", creds2)
+// 	fmt.Print("Newly-issued SSH credentials: ", creds)
+// 	fmt.Print("Signed SSH credential: ", creds2)
 // }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying an alias (alternative or friendly name) when adding or viewing SSH hosts.

- **Tests**
  - Updated test code to reflect new alias functionality (no impact on current test execution).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->