### PR TITLE
fix: get access token when manually set

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -50,6 +50,13 @@ func (a *Auth) SetAccessToken(accessToken string) {
 }
 
 func (a *Auth) GetAccessToken() string {
+	// case: user has set an access token manually, so we get it directly from the credential
+	if a.client.authMethod == util.ACCESS_TOKEN {
+		if parsedCreds, ok := a.client.credential.(models.AccessTokenCredential); ok {
+			return parsedCreds.AccessToken
+		}
+		return ""
+	}
 	return a.client.tokenDetails.AccessToken
 }
 

--- a/client.go
+++ b/client.go
@@ -127,6 +127,8 @@ func (c *InfisicalClient) setPlainAccessToken(accessToken string) {
 	c.authMethod = util.ACCESS_TOKEN
 	c.httpClient.SetAuthScheme("Bearer")
 	c.httpClient.SetAuthToken(accessToken)
+
+	c.credential = models.AccessTokenCredential{AccessToken: accessToken}
 }
 
 func NewInfisicalClient(context context.Context, config Config) InfisicalClientInterface {


### PR DESCRIPTION
This PR is a fix for the `Auth()GetAccessToken()` function, which doesn't return anything when the access token is set with the `Auth().SetAccessToken()` function.