### PR TITLE
fix(auth): revoke token when using plain access token

### DIFF
--- a/client.go
+++ b/client.go
@@ -128,6 +128,7 @@ func (c *InfisicalClient) setPlainAccessToken(accessToken string) {
 	c.httpClient.SetAuthScheme("Bearer")
 	c.httpClient.SetAuthToken(accessToken)
 
+	c.tokenDetails.AccessToken = accessToken
 	c.credential = models.AccessTokenCredential{AccessToken: accessToken}
 }
 


### PR DESCRIPTION
Currently revoking an access token doesn't work when using a plain access token. This PR serves as a fix for this issue by setting the access token on the token details inside the client.