### PR TITLE
Added new parameter to ListSecretsV3RawRequest to skip unique validation

### DIFF
--- a/packages/api/secrets/list_secrets.go
+++ b/packages/api/secrets/list_secrets.go
@@ -45,6 +45,7 @@ func CallListSecretsV3(cache *expirable.LRU[string, interface{}], httpClient *re
 			"expandSecretReferences": fmt.Sprintf("%t", request.ExpandSecretReferences),
 			"include_imports":        fmt.Sprintf("%t", request.IncludeImports),
 			"recursive":              fmt.Sprintf("%t", request.Recursive),
+			"skip_unique_validation": fmt.Sprintf("%t", request.SkipUniqueValidation),
 		}).Get("/v3/secrets/raw")
 
 	if err != nil {

--- a/packages/api/secrets/models.go
+++ b/packages/api/secrets/models.go
@@ -14,6 +14,7 @@ type ListSecretsV3RawRequest struct {
 	IncludeImports         bool   `json:"include_imports"`
 	Recursive              bool   `json:"recursive"`
 	SecretPath             string `json:"secretPath,omitempty"`
+	SkipUniqueValidation   bool   `json:"-"`
 }
 
 type ListSecretsV3RawResponse struct {

--- a/packages/util/helper.go
+++ b/packages/util/helper.go
@@ -32,12 +32,20 @@ func PrintWarning(message string) {
 	fmt.Fprintf(os.Stderr, "[Infisical] Warning: %v \n", message)
 }
 
-func EnsureUniqueSecretsByKey(secrets *[]models.Secret) {
+func EnsureUniqueSecretsByKey(secrets *[]models.Secret, skipUniqueKey bool) {
 	secretMap := make(map[string]models.Secret)
 
 	// Move secrets to a map to ensure uniqueness
 	for _, secret := range *secrets {
-		secretMap[secret.SecretKey] = secret // Maps will overwrite existing entry with the same key
+		var key string
+		if skipUniqueKey {
+			// Create a composite key using both SecretPath and SecretKey
+			key = secret.SecretPath + ":" + secret.SecretKey
+		} else {
+			// Use only SecretKey for global uniqueness (original behavior)
+			key = secret.SecretKey
+		}
+		secretMap[key] = secret // Maps will overwrite existing entry with the same key
 	}
 
 	// Clear the slice

--- a/secrets.go
+++ b/secrets.go
@@ -48,7 +48,7 @@ func (s *Secrets) List(options ListSecretsOptions) ([]models.Secret, error) {
 	}
 
 	if options.Recursive {
-		util.EnsureUniqueSecretsByKey(&res.Secrets)
+		util.EnsureUniqueSecretsByKey(&res.Secrets, options.SkipUniqueValidation)
 	}
 
 	secrets := append([]models.Secret(nil), res.Secrets...) // Clone main secrets slice, we will modify this if imports are enabled


### PR DESCRIPTION
Added new parameter to ListSecretsV3RawRequest to skip unique validation, with this new parameter we can allow users to retrieve secrets recursively and allow them to use the same key on different folders.