### PR TITLE
fix(aws-auth): follow full credential chain and honor AWS_DEFAULT_REGION

### DIFF
--- a/packages/util/auth.go
+++ b/packages/util/auth.go
@@ -196,10 +196,13 @@ func GetGCPIamServiceAccountToken(identityID string, serviceAccountKeyPath strin
 }
 
 func GetAwsRegion() (string, error) {
-	// in Lambda environments, the region is available in the AWS_REGION environment variable
-	region := os.Getenv("AWS_REGION")
+	// Lambda, ECS and most SDK-managed environments expose the region via the
+	// standard AWS env vars. Honor both before reaching for the metadata service.
+	if region := os.Getenv("AWS_REGION"); region != "" {
+		return region, nil
+	}
 
-	if region != "" {
+	if region := os.Getenv("AWS_DEFAULT_REGION"); region != "" {
 		return region, nil
 	}
 
@@ -216,21 +219,12 @@ func GetAwsRegion() (string, error) {
 }
 
 func RetrieveAwsCredentials() (credentials aws.Credentials, region string, err error) {
-	presetAwsCfg, err := config.LoadDefaultConfig(context.TODO())
-
-	if err == nil && presetAwsCfg.Region != "" {
-		creds, err := presetAwsCfg.Credentials.Retrieve(context.TODO())
-		if err == nil {
-			return creds, presetAwsCfg.Region, nil
-		}
-	}
-
-	awsRegion, err := GetAwsRegion()
-	if err != nil {
-		return aws.Credentials{}, "", err
-	}
-
-	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(awsRegion))
+	// Resolve credentials through the standard AWS provider chain (env vars,
+	// shared config, ECS/EKS container credentials, then EC2 instance metadata).
+	// Credentials must not depend on the region being known: ECS task roles, for
+	// example, supply credentials via AWS_CONTAINER_CREDENTIALS_RELATIVE_URI while
+	// leaving the region to be set separately.
+	awsCfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		return aws.Credentials{}, "", fmt.Errorf("unable to load SDK config, %v", err)
 	}
@@ -238,6 +232,18 @@ func RetrieveAwsCredentials() (credentials aws.Credentials, region string, err e
 	creds, err := awsCfg.Credentials.Retrieve(context.TODO())
 	if err != nil {
 		return aws.Credentials{}, "", fmt.Errorf("error retrieving credentials: %v", err)
+	}
+
+	// Prefer the region resolved by the SDK config; fall back to the env vars and,
+	// only as a last resort, the EC2 metadata service. Fetching the region must
+	// not short-circuit credential resolution, otherwise environments without IMDS
+	// (e.g. ECS Fargate) fail even when credentials are available.
+	awsRegion := awsCfg.Region
+	if awsRegion == "" {
+		awsRegion, err = GetAwsRegion()
+		if err != nil {
+			return aws.Credentials{}, "", err
+		}
 	}
 
 	return creds, awsRegion, nil

--- a/packages/util/auth_test.go
+++ b/packages/util/auth_test.go
@@ -1,0 +1,29 @@
+package util
+
+import "testing"
+
+func TestGetAwsRegion_PrefersAwsRegionEnv(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_DEFAULT_REGION", "eu-west-1")
+
+	region, err := GetAwsRegion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if region != "us-east-1" {
+		t.Fatalf("expected AWS_REGION to win, got %q", region)
+	}
+}
+
+func TestGetAwsRegion_FallsBackToDefaultRegionEnv(t *testing.T) {
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "ap-south-1")
+
+	region, err := GetAwsRegion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if region != "ap-south-1" {
+		t.Fatalf("expected AWS_DEFAULT_REGION fallback, got %q", region)
+	}
+}


### PR DESCRIPTION
## Description

`RetrieveAwsCredentials` only returned the credentials resolved by the default AWS provider chain when a region had already been detected. When the region was unknown, it fell through to `GetAwsRegion`, which calls the EC2 instance metadata service (`169.254.169.254`) directly.

On ECS Fargate there is no instance metadata endpoint, so aws-iam auth failed even when valid credentials were available — task-role credentials via `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, or plain `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars. Setting `AWS_EC2_METADATA_DISABLED=true` didn't help because the metadata call is a raw HTTP request rather than going through the SDK.

This was reported for the CLI in Infisical/infisical#6523; the CLI delegates aws-iam login to this SDK, and the KMIP/gateway/relay flows call `RetrieveAwsCredentials` too, so they share the same gap.

## Changes

- `RetrieveAwsCredentials`: resolve credentials from the standard provider chain unconditionally (env vars → shared config → ECS/EKS container credentials → EC2 IMDS), then resolve the region separately. Region detection no longer short-circuits credential resolution, so an environment without IMDS still authenticates as long as credentials are present.
- Region resolution order is now: SDK config → `AWS_REGION` → `AWS_DEFAULT_REGION` → EC2 metadata service.
- `GetAwsRegion`: honor `AWS_DEFAULT_REGION` in addition to `AWS_REGION` before reaching for IMDS.

## Testing

Added unit tests for the region precedence (`AWS_REGION` over `AWS_DEFAULT_REGION`, and the `AWS_DEFAULT_REGION` fallback). `go build ./...`, `go vet ./packages/util/` and the new tests pass locally.